### PR TITLE
[STEP-05/06] 코치님 피드백 내용 정리 및 리팩토링

### DIFF
--- a/src/main/java/com/hhplusecommerce/application/payment/PaymentFacade.java
+++ b/src/main/java/com/hhplusecommerce/application/payment/PaymentFacade.java
@@ -38,7 +38,7 @@ public class PaymentFacade {
         BigDecimal finalAmount = order.getFinalAmount();
 
         // 잔액 차감
-        balanceService.deductBalance(userId, new BalanceCommand(finalAmount));
+        balanceService.deductBalance(new BalanceCommand(userId, finalAmount));
 
         // 주문 항목 조회 및 재고 차감
         List<OrderItem> orderItems = orderService.getOrderItems(order.getId());

--- a/src/main/java/com/hhplusecommerce/domain/balance/BalanceChangeType.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/BalanceChangeType.java
@@ -1,8 +1,30 @@
 package com.hhplusecommerce.domain.balance;
 
+import com.hhplusecommerce.support.exception.CustomException;
+import com.hhplusecommerce.support.exception.ErrorType;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
 public enum BalanceChangeType {
-    CHARGE("충전"),
-    DEDUCT("차감");
+
+    CHARGE("충전") {
+        @Override
+        public void validate(BigDecimal amount) {
+            if (amount.compareTo(BigDecimal.ZERO) < 0) {
+                throw new CustomException(ErrorType.INVALID_BALANCE_AMOUNT);
+            }
+        }
+    },
+
+    DEDUCT("차감") {
+        @Override
+        public void validate(BigDecimal amount) {
+            if (amount.compareTo(BigDecimal.ZERO) > 0) {
+                throw new CustomException(ErrorType.INVALID_BALANCE_AMOUNT);
+            }
+        }
+    };
 
     private final String description;
 
@@ -14,13 +36,9 @@ public enum BalanceChangeType {
         return description;
     }
 
-    public static boolean isValid(String value) {
-        for (BalanceChangeType type : BalanceChangeType.values()) {
-            if (type.name().equals(value)) {
-                return true;
-            }
-        }
+    public abstract void validate(BigDecimal amount);
 
-        return false;
+    public static boolean isValid(String value) {
+        return Arrays.stream(values()).anyMatch(type -> type.name().equals(value));
     }
 }

--- a/src/main/java/com/hhplusecommerce/domain/balance/BalanceCommand.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/BalanceCommand.java
@@ -2,5 +2,5 @@ package com.hhplusecommerce.domain.balance;
 
 import java.math.BigDecimal;
 
-public record BalanceCommand(BigDecimal amount) {
+public record BalanceCommand(Long userId, BigDecimal amount) {
 }

--- a/src/main/java/com/hhplusecommerce/domain/balance/BalanceService.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/BalanceService.java
@@ -56,8 +56,6 @@ public class BalanceService {
         UserBalance userBalance = balanceRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorType.USER_BALANCE_NOT_FOUND));
 
-        if (userBalance.getAmount().compareTo(requiredAmount) < 0) {
-            throw new CustomException(ErrorType.INSUFFICIENT_BALANCE);
-        }
+        userBalance.validateEnoughAmount(requiredAmount);
     }
 }

--- a/src/main/java/com/hhplusecommerce/domain/balance/UserBalance.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/UserBalance.java
@@ -37,6 +37,16 @@ public class UserBalance {
     }
 
     /**
+     * 결제 또는 차감을 위해 충분한 잔액을 보유하고 있는지 검증
+     */
+    public void validateEnoughAmount(BigDecimal requiredAmount) {
+        validatePositiveAmount(requiredAmount);
+        if (this.amount.compareTo(requiredAmount) < 0) {
+            throw new CustomException(ErrorType.INSUFFICIENT_BALANCE);
+        }
+    }
+
+    /**
      * 잔액 충전
      */
     public void charge(BigDecimal chargeAmount) {
@@ -57,6 +67,9 @@ public class UserBalance {
         this.updatedAt = LocalDateTime.now();
     }
 
+    /**
+     * 0보다 큰 금액인지 검증
+     */
     private void validatePositiveAmount(BigDecimal amount) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new CustomException(ErrorType.INVALID_BALANCE_AMOUNT);

--- a/src/main/java/com/hhplusecommerce/domain/balance/UserBalance.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/UserBalance.java
@@ -24,9 +24,13 @@ public class UserBalance {
 
     @Builder
     public UserBalance(Long userId, BigDecimal amount) {
-        if (amount.compareTo(BigDecimal.ZERO) < 0) {
+        if (userId == null) {
+            throw new CustomException(ErrorType.USER_BALANCE_NOT_FOUND);
+        }
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {
             throw new CustomException(ErrorType.INVALID_BALANCE_AMOUNT);
         }
+
         this.userId = userId;
         this.amount = amount;
         this.updatedAt = LocalDateTime.now();
@@ -34,16 +38,6 @@ public class UserBalance {
 
     public static UserBalance initialize(Long userId) {
         return new UserBalance(userId, BigDecimal.ZERO);
-    }
-
-    /**
-     * 결제 또는 차감을 위해 충분한 잔액을 보유하고 있는지 검증
-     */
-    public void validateEnoughAmount(BigDecimal requiredAmount) {
-        validatePositiveAmount(requiredAmount);
-        if (this.amount.compareTo(requiredAmount) < 0) {
-            throw new CustomException(ErrorType.INSUFFICIENT_BALANCE);
-        }
     }
 
     /**
@@ -65,6 +59,16 @@ public class UserBalance {
         }
         this.amount = this.amount.subtract(deductAmount);
         this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 결제 또는 차감을 위해 충분한 잔액을 보유하고 있는지 검증
+     */
+    public void validateEnoughAmount(BigDecimal requiredAmount) {
+        validatePositiveAmount(requiredAmount);
+        if (this.amount.compareTo(requiredAmount) < 0) {
+            throw new CustomException(ErrorType.INSUFFICIENT_BALANCE);
+        }
     }
 
     /**

--- a/src/main/java/com/hhplusecommerce/domain/coupon/Coupon.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/Coupon.java
@@ -2,11 +2,13 @@ package com.hhplusecommerce.domain.coupon;
 
 import com.hhplusecommerce.support.exception.CustomException;
 import com.hhplusecommerce.support.exception.ErrorType;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -83,21 +85,7 @@ public class Coupon {
     public BigDecimal discountFor(BigDecimal totalAmount) {
         validateDiscountValue(this.discountValue);
 
-        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            return BigDecimal.ZERO;
-        }
-
-        if (discountType == CouponDiscountType.FIXED_RATE) {
-            return totalAmount
-                    .multiply(discountValue)
-                    .divide(BigDecimal.valueOf(100), 0, RoundingMode.FLOOR);
-        }
-
-        if (discountType == CouponDiscountType.FIXED_AMOUNT) {
-            return discountValue.min(totalAmount);
-        }
-
-        return BigDecimal.ZERO;
+        return discountType.discount(totalAmount, discountValue);
     }
 
     /**

--- a/src/main/java/com/hhplusecommerce/domain/coupon/Coupon.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/Coupon.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 
 /**
  * 쿠폰 정책
- *
+ * <p>
  * - 쿠폰의 할인 조건 및 정책 관리
  * - 유효한 쿠폰인지 판단 (기간, 상태 등)
  * - 발급 수량 관리
@@ -44,16 +44,46 @@ public class Coupon {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Coupon(String couponName, CouponDiscountType discountType, BigDecimal discountValue, int maxQuantity, LocalDate validStartDate, LocalDate validEndDate, int issuedQuantity, CouponType couponType) {
+    public Coupon(String couponName,
+                  CouponDiscountType discountType,
+                  BigDecimal discountValue,
+                  int maxQuantity,
+                  LocalDate validStartDate,
+                  LocalDate validEndDate,
+                  int issuedQuantity,
+                  CouponType couponType) {
+
+        if (couponName == null || couponName.isBlank()) {
+            throw new CustomException(ErrorType.INVALID_COUPON_NAME);
+        }
+
+        if (discountType == null) {
+            throw new CustomException(ErrorType.INVALID_COUPON_DISCOUNT_TYPE);
+        }
+
         validateDiscountValue(discountValue);
+
+        if (maxQuantity < 1) {
+            throw new CustomException(ErrorType.INVALID_COUPON_QUANTITY);
+        }
+
+        if (validStartDate == null || validEndDate == null || !validStartDate.isBefore(validEndDate)) {
+            throw new CustomException(ErrorType.INVALID_COUPON_DATE_RANGE);
+        }
+
+        if (couponType == null) {
+            throw new CustomException(ErrorType.INVALID_COUPON_TYPE);
+        }
+
         this.couponName = couponName;
         this.discountType = discountType;
         this.discountValue = discountValue;
         this.maxQuantity = maxQuantity;
+        this.issuedQuantity = issuedQuantity;
         this.validStartDate = validStartDate;
         this.validEndDate = validEndDate;
-        this.issuedQuantity = issuedQuantity;
         this.couponType = couponType;
+        this.couponStatus = CouponStatus.ACTIVE;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/hhplusecommerce/domain/coupon/CouponDiscountType.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/CouponDiscountType.java
@@ -1,8 +1,27 @@
 package com.hhplusecommerce.domain.coupon;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 public enum CouponDiscountType {
-    FIXED_AMOUNT("정액 할인"),
-    FIXED_RATE("비율 할인");
+
+    FIXED_AMOUNT("정액할인") {
+        @Override
+        public BigDecimal discount(BigDecimal totalAmount, BigDecimal value) {
+            if (totalAmount == null || value == null) return BigDecimal.ZERO;
+            return value.min(totalAmount);
+        }
+    },
+
+    FIXED_RATE("정률할인") {
+        @Override
+        public BigDecimal discount(BigDecimal totalAmount, BigDecimal value) {
+            if (totalAmount == null || value == null) return BigDecimal.ZERO;
+            return totalAmount
+                    .multiply(value)
+                    .divide(BigDecimal.valueOf(100), 0, RoundingMode.FLOOR);
+        }
+    };
 
     private final String description;
 
@@ -13,4 +32,6 @@ public enum CouponDiscountType {
     public String getDescription() {
         return description;
     }
+
+    public abstract BigDecimal discount(BigDecimal totalAmount, BigDecimal value);
 }

--- a/src/main/java/com/hhplusecommerce/domain/coupon/CouponHistory.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/CouponHistory.java
@@ -7,7 +7,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +21,6 @@ import java.time.LocalDateTime;
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Entity
 public class CouponHistory {
 
@@ -36,6 +34,33 @@ public class CouponHistory {
     private CouponUsageStatus couponUsageStatus;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public CouponHistory(Long id,
+                         Long userId,
+                         Long couponId,
+                         LocalDateTime issueDate,
+                         LocalDateTime useDate,
+                         CouponUsageStatus couponUsageStatus,
+                         LocalDateTime createdAt,
+                         LocalDateTime updatedAt) {
+
+        if (couponId == null) {
+            throw new CustomException(ErrorType.INVALID_COUPON_ISSUE_DATA);
+        }
+
+        if (couponUsageStatus == null) {
+            throw new CustomException(ErrorType.INVALID_COUPON_STATUS);
+        }
+
+        this.id = id;
+        this.userId = userId;
+        this.couponId = couponId;
+        this.issueDate = issueDate;
+        this.useDate = useDate;
+        this.couponUsageStatus = couponUsageStatus;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
 
     /**
      * 쿠폰 발급 이력 생성
@@ -54,7 +79,7 @@ public class CouponHistory {
     }
 
     /**
-     * 쿠폰 사용 가능 여부 확인
+     * 쿠폰이 사용 가능한 상태인지 확인
      */
     public boolean isAvailable() {
         return this.couponUsageStatus == CouponUsageStatus.AVAILABLE &&
@@ -62,7 +87,7 @@ public class CouponHistory {
     }
 
     /**
-     * 쿠폰 사용 처리
+     * 쿠폰 사용 처리 (중복 사용 방지)
      */
     public void use() {
         if (!isAvailable()) {
@@ -71,5 +96,14 @@ public class CouponHistory {
         this.couponUsageStatus = CouponUsageStatus.USED;
         this.useDate = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 쿠폰 소유자가 맞는지 검증
+     */
+    public void validateOwner(Long userId) {
+        if (!this.userId.equals(userId)) {
+            throw new CustomException(ErrorType.UNAUTHORIZED_COUPON_ACCESS);
+        }
     }
 }

--- a/src/main/java/com/hhplusecommerce/domain/coupon/CouponService.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/CouponService.java
@@ -66,9 +66,7 @@ public class CouponService {
         CouponHistory couponHistory = couponHistoryRepository.findById(couponIssueId)
                 .orElseThrow(() -> new CustomException(ErrorType.COUPON_NOT_FOUND));
 
-        if (!couponHistory.getUserId().equals(userId)) {
-            throw new CustomException(ErrorType.UNAUTHORIZED_COUPON_ACCESS);
-        }
+        couponHistory.validateOwner(userId);
 
         return couponHistory;
     }

--- a/src/main/java/com/hhplusecommerce/domain/order/Order.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/Order.java
@@ -50,7 +50,7 @@ public class Order {
      * 주문 완료 처리
      */
     public void complete() {
-        if (this.status != OrderStatus.PAYMENT_WAIT) {
+        if (!this.status.canComplete()) {
             throw new CustomException(ErrorType.INVALID_ORDER_STATUS_TO_COMPLETE);
         }
         this.status = OrderStatus.COMPLETED;
@@ -61,7 +61,7 @@ public class Order {
      * 주문 기한 만료 처리
      */
     public void expire() {
-        if (this.status != OrderStatus.PAYMENT_WAIT) {
+        if (!this.status.canExpire()) {
             throw new CustomException(ErrorType.INVALID_ORDER_STATUS_TO_EXPIRE);
         }
         this.status = OrderStatus.EXPIRED;

--- a/src/main/java/com/hhplusecommerce/domain/order/Order.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/Order.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 /**
  * 주문 정보 관리
- *
+ * <p>
  * - 사용자 주문서 생성 및 상태 관리
  * - 총 금액 및 최종 결제 금액 저장
  * - 주문 완료/취소/만료 상태 처리
@@ -35,7 +35,25 @@ public class Order {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Order(Long userId, Long couponIssueId, LocalDateTime orderDate, BigDecimal totalAmount, BigDecimal finalAmount, OrderStatus status) {
+    public Order(Long userId, Long couponIssueId, LocalDateTime orderDate,
+                 BigDecimal totalAmount, BigDecimal finalAmount, OrderStatus status) {
+
+        if (userId == null) {
+            throw new CustomException(ErrorType.INVALID_USER_ID);
+        }
+        if (orderDate == null) {
+            throw new CustomException(ErrorType.INVALID_ORDER_DATE);
+        }
+        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CustomException(ErrorType.INVALID_ORDER_TOTAL_AMOUNT);
+        }
+        if (finalAmount == null || finalAmount.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CustomException(ErrorType.INVALID_ORDER_FINAL_AMOUNT);
+        }
+        if (status == null) {
+            throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
+        }
+
         this.userId = userId;
         this.couponIssueId = couponIssueId;
         this.orderDate = orderDate;

--- a/src/main/java/com/hhplusecommerce/domain/order/Order.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/Order.java
@@ -7,14 +7,9 @@ import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
-/**
- * 주문 정보 관리
- * <p>
- * - 사용자 주문서 생성 및 상태 관리
- * - 총 금액 및 최종 결제 금액 저장
- * - 주문 완료/취소/만료 상태 처리
- */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,35 +19,36 @@ public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private Long userId;
+
     private Long couponIssueId;
+
     private LocalDateTime orderDate;
+
     private BigDecimal totalAmount;
+
     private BigDecimal finalAmount;
+
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
+
     private LocalDateTime createdAt;
+
     private LocalDateTime updatedAt;
 
-    @Builder
-    public Order(Long userId, Long couponIssueId, LocalDateTime orderDate,
-                 BigDecimal totalAmount, BigDecimal finalAmount, OrderStatus status) {
+    @Transient
+    private List<OrderItem> orderItems = new ArrayList<>();
 
-        if (userId == null) {
-            throw new CustomException(ErrorType.INVALID_USER_ID);
-        }
-        if (orderDate == null) {
-            throw new CustomException(ErrorType.INVALID_ORDER_DATE);
-        }
-        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) < 0) {
+    private Order(Long userId, Long couponIssueId, LocalDateTime orderDate,
+                  BigDecimal totalAmount, BigDecimal finalAmount, OrderStatus status) {
+        if (userId == null) throw new CustomException(ErrorType.INVALID_USER_ID);
+        if (orderDate == null) throw new CustomException(ErrorType.INVALID_ORDER_DATE);
+        if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) < 0)
             throw new CustomException(ErrorType.INVALID_ORDER_TOTAL_AMOUNT);
-        }
-        if (finalAmount == null || finalAmount.compareTo(BigDecimal.ZERO) < 0) {
+        if (finalAmount == null || finalAmount.compareTo(BigDecimal.ZERO) < 0)
             throw new CustomException(ErrorType.INVALID_ORDER_FINAL_AMOUNT);
-        }
-        if (status == null) {
-            throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
-        }
+        if (status == null) throw new CustomException(ErrorType.INVALID_ORDER_STATUS);
 
         this.userId = userId;
         this.couponIssueId = couponIssueId;
@@ -62,6 +58,39 @@ public class Order {
         this.status = status;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 주문 생성
+     */
+    public static Order create(OrderCommand command, BigDecimal totalAmount, BigDecimal finalAmount) {
+        Order order = new Order(
+                command.userId(),
+                command.couponIssueId(),
+                LocalDateTime.now(),
+                totalAmount,
+                finalAmount,
+                OrderStatus.PAYMENT_WAIT
+        );
+
+        List<OrderItem> items = command.orderItems().stream()
+                .map(item -> OrderItem.builder()
+                        .orderId(null) // 아직 저장 전이라 ID 없음
+                        .productId(item.productId())
+                        .quantity(item.quantity())
+                        .price(item.price())
+                        .build())
+                .toList();
+
+        order.orderItems.addAll(items);
+        return order;
+    }
+
+    /**
+     * 주문에 포함된 주문 항목 리스트 반환
+     */
+    public List<OrderItem> getOrderItems() {
+        return orderItems;
     }
 
     /**
@@ -76,7 +105,7 @@ public class Order {
     }
 
     /**
-     * 주문 기한 만료 처리
+     * 주문 만료 처리
      */
     public void expire() {
         if (!this.status.canExpire()) {

--- a/src/main/java/com/hhplusecommerce/domain/order/OrderService.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/OrderService.java
@@ -24,27 +24,9 @@ public class OrderService {
      */
     @Transactional
     public Long createOrder(OrderCommand command, BigDecimal totalAmount, BigDecimal finalAmount) {
-        Order order = Order.builder()
-                .userId(command.userId())
-                .couponIssueId(command.couponIssueId())
-                .orderDate(LocalDateTime.now())
-                .totalAmount(totalAmount)
-                .finalAmount(finalAmount)
-                .status(OrderStatus.PAYMENT_WAIT)
-                .build();
-
+        Order order = Order.create(command, totalAmount, finalAmount);
         orderRepository.save(order);
-
-        List<OrderItem> orderItems = command.orderItems().stream()
-                .map(item -> OrderItem.builder()
-                        .orderId(order.getId())
-                        .productId(item.productId())
-                        .quantity(item.quantity())
-                        .price(item.price())
-                        .build())
-                .collect(Collectors.toList());
-
-        orderItemRepository.saveAll(orderItems);
+        orderItemRepository.saveAll(order.getOrderItems());
 
         return order.getId();
     }
@@ -72,7 +54,6 @@ public class OrderService {
                 .orElseThrow(() -> new CustomException(ErrorType.ORDER_NOT_FOUND));
         order.complete();
     }
-
 
     /**
      * 주문 만료 처리

--- a/src/main/java/com/hhplusecommerce/domain/order/OrderStatus.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/OrderStatus.java
@@ -1,7 +1,17 @@
 package com.hhplusecommerce.domain.order;
 
 public enum OrderStatus {
-    PAYMENT_WAIT("주문서 작성 후 결제 대기"),
+    PAYMENT_WAIT("주문서 작성 후 결제 대기") {
+        @Override
+        public boolean canComplete() {
+            return true;
+        }
+
+        @Override
+        public boolean canExpire() {
+            return true;
+        }
+    },
     COMPLETED("주문 최종 완료"),
     CANCELED("주문 취소"),
     EXPIRED("주문 기한 만료");
@@ -14,5 +24,21 @@ public enum OrderStatus {
 
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * 현재 상태(OrderStatus)가 '주문 완료' 상태로 변경될 수 있는 상태인지 여부를 반환
+     * 기본적으로는 불가능하며, PAYMENT_WAIT 상태에서만 true 반환
+     */
+    public boolean canComplete() {
+        return false;
+    }
+
+    /**
+     * 현재 상태(OrderStatus)가 '주문 만료' 상태로 변경될 수 있는 상태인지 여부를 반환
+     * 기본적으로는 불가능하며, PAYMENT_WAIT 상태에서만 true 반환
+     */
+    public boolean canExpire() {
+        return false;
     }
 }

--- a/src/main/java/com/hhplusecommerce/domain/payment/Payment.java
+++ b/src/main/java/com/hhplusecommerce/domain/payment/Payment.java
@@ -1,16 +1,16 @@
 package com.hhplusecommerce.domain.payment;
 
-import jakarta.persistence.*;
-import lombok.*;
 import com.hhplusecommerce.support.exception.CustomException;
 import com.hhplusecommerce.support.exception.ErrorType;
+import jakarta.persistence.*;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
  * 결제 정보 (결제 금액, 상태 등)를 관리
- *
+ * <p>
  * - 주문에 대한 결제 금액 및 상태 저장
  * - 결제 성공/실패 상태 처리
  */
@@ -31,9 +31,16 @@ public class Payment {
 
     @Builder
     public Payment(Long orderId, BigDecimal paidAmount, PaymentStatus paymentStatus) {
-        if (paidAmount.compareTo(BigDecimal.ZERO) <= 0) {
+        if (orderId == null) {
+            throw new CustomException(ErrorType.INVALID_PAYMENT_ORDER_ID);
+        }
+        if (paidAmount == null || paidAmount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new CustomException(ErrorType.INVALID_PAYMENT_AMOUNT);
         }
+        if (paymentStatus == null) {
+            throw new CustomException(ErrorType.INVALID_PAYMENT_STATUS);
+        }
+
         this.orderId = orderId;
         this.paidAmount = paidAmount;
         this.paymentStatus = paymentStatus;

--- a/src/main/java/com/hhplusecommerce/domain/popularProduct/PopularProduct.java
+++ b/src/main/java/com/hhplusecommerce/domain/popularProduct/PopularProduct.java
@@ -1,5 +1,7 @@
 package com.hhplusecommerce.domain.popularProduct;
 
+import com.hhplusecommerce.support.exception.CustomException;
+import com.hhplusecommerce.support.exception.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
@@ -26,6 +28,19 @@ public class PopularProduct {
 
     @Builder
     public PopularProduct(Long productId, String productName, Long price, int totalSold) {
+        if (productId == null || productId <= 0) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_ID);
+        }
+        if (productName == null || productName.isBlank()) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_NAME);
+        }
+        if (price == null || price < 0) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_PRICE);
+        }
+        if (totalSold < 0) {
+            throw new CustomException(ErrorType.INVALID_TOTAL_SOLD_COUNT);
+        }
+
         this.productId = productId;
         this.productName = productName;
         this.price = price;

--- a/src/main/java/com/hhplusecommerce/domain/popularProduct/ProductSalesStats.java
+++ b/src/main/java/com/hhplusecommerce/domain/popularProduct/ProductSalesStats.java
@@ -1,5 +1,7 @@
 package com.hhplusecommerce.domain.popularProduct;
 
+import com.hhplusecommerce.support.exception.CustomException;
+import com.hhplusecommerce.support.exception.ErrorType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -8,7 +10,7 @@ import java.time.LocalDate;
 
 /**
  * 상품별 일자별 판매 통계 정보를 관리
- *
+ * <p>
  * - 특정 상품의 판매 수량 및 총 판매 금액을 일자 단위로 누적 관리
  * - 결제 완료 시 판매 정보를 기록하며, 추후 인기 상품 조회에 활용됨
  * - 생성 시 기본 수치는 0으로 시작하고, 이후 record 메서드를 통해 누적
@@ -27,6 +29,13 @@ public class ProductSalesStats {
      * 주어진 상품 ID와 날짜 기준으로 초기 판매 통계 생성
      */
     public static ProductSalesStats initialize(Long productId, LocalDate saleDate) {
+        if (productId == null || productId <= 0) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_ID);
+        }
+        if (saleDate == null) {
+            throw new CustomException(ErrorType.INVALID_SALE_DATE);
+        }
+
         return new ProductSalesStats(null, productId, saleDate, 0, BigDecimal.ZERO);
     }
 
@@ -35,6 +44,10 @@ public class ProductSalesStats {
      * - 음수도 허용되며, 누적 또는 차감 형태로 적용
      */
     public void record(int quantity, BigDecimal amount) {
+        if (amount == null) {
+            throw new CustomException(ErrorType.INVALID_SALES_AMOUNT);
+        }
+
         this.quantitySold += quantity;
         this.totalSalesAmount = this.totalSalesAmount.add(amount);
     }

--- a/src/main/java/com/hhplusecommerce/domain/product/Product.java
+++ b/src/main/java/com/hhplusecommerce/domain/product/Product.java
@@ -1,5 +1,7 @@
 package com.hhplusecommerce.domain.product;
 
+import com.hhplusecommerce.support.exception.CustomException;
+import com.hhplusecommerce.support.exception.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
@@ -28,6 +30,16 @@ public class Product {
 
     @Builder
     public Product(Long id, String name, String category, BigDecimal price) {
+        if (name == null || name.isBlank()) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_NAME);
+        }
+        if (category == null || category.isBlank()) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_CATEGORY);
+        }
+        if (price == null || price.compareTo(BigDecimal.ZERO) < 0) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_PRICE);
+        }
+
         this.id = id;
         this.name = name;
         this.category = category;

--- a/src/main/java/com/hhplusecommerce/domain/product/ProductInventory.java
+++ b/src/main/java/com/hhplusecommerce/domain/product/ProductInventory.java
@@ -30,15 +30,22 @@ public class ProductInventory {
 
     @Builder
     public ProductInventory(Long productId, int stock) {
+        if (productId == null || productId <= 0) {
+            throw new CustomException(ErrorType.INVALID_PRODUCT_ID);
+        }
+        if (stock < 0) {
+            throw new CustomException(ErrorType.INVALID_STOCK_AMOUNT);
+        }
+
         this.productId = productId;
-        this.stock = validatePositive(stock);
+        this.stock = stock;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
-
     /**
      * 재고 증가
+     *
      * @param amount 증가할 수량 (양수)
      */
     public void increase(int amount) {
@@ -50,6 +57,7 @@ public class ProductInventory {
 
     /**
      * 재고를 차감
+     *
      * @param amount 차감할 수량 (양수)
      */
     public void decrease(int amount) {

--- a/src/main/java/com/hhplusecommerce/interfaces/balance/BalanceController.java
+++ b/src/main/java/com/hhplusecommerce/interfaces/balance/BalanceController.java
@@ -43,7 +43,7 @@ public class BalanceController {
     })
     public ResponseEntity<ApiResult<BalanceResponse>> chargeBalance(@PathVariable Long userId,
                                                                     @Valid @RequestBody BalanceRequest request) {
-        BalanceResult balanceResult = balanceService.chargeBalance(userId, request.toCommand());
+        BalanceResult balanceResult = balanceService.chargeBalance(request.toCommand(userId));
         return ResponseEntity.ok(ApiResult.success(BalanceResponse.from(balanceResult)));
     }
 
@@ -59,7 +59,7 @@ public class BalanceController {
     })
     public ResponseEntity<ApiResult<BalanceResponse>> deductBalance(@PathVariable Long userId,
                                                                     @Valid @RequestBody BalanceRequest request) {
-        BalanceResult balanceResult = balanceService.deductBalance(userId, request.toCommand());
+        BalanceResult balanceResult = balanceService.deductBalance(request.toCommand(userId));
         return ResponseEntity.ok(ApiResult.success(BalanceResponse.from(balanceResult)));
     }
 }

--- a/src/main/java/com/hhplusecommerce/interfaces/balance/BalanceRequest.java
+++ b/src/main/java/com/hhplusecommerce/interfaces/balance/BalanceRequest.java
@@ -18,7 +18,7 @@ public class BalanceRequest {
         return amount;
     }
 
-    public BalanceCommand toCommand() {
-        return new BalanceCommand(amount);
+    public BalanceCommand toCommand(Long userId) {
+        return new BalanceCommand(userId, amount);
     }
 }

--- a/src/main/java/com/hhplusecommerce/support/exception/ErrorType.java
+++ b/src/main/java/com/hhplusecommerce/support/exception/ErrorType.java
@@ -7,6 +7,13 @@ public enum ErrorType {
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품의 재고가 부족합니다."),
     INVALID_STOCK_AMOUNT(HttpStatus.BAD_REQUEST, "수량은 1 이상이어야 합니다."),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
+    INVALID_PRODUCT_ID(HttpStatus.NOT_FOUND, "상품 ID를 확인해 주세요"),
+    INVALID_PRODUCT_NAME(HttpStatus.BAD_REQUEST, "상품 이름은 필수입니다."),
+    INVALID_PRODUCT_CATEGORY(HttpStatus.BAD_REQUEST, "상품 카테고리는 필수입니다."),
+    INVALID_PRODUCT_PRICE(HttpStatus.BAD_REQUEST, "상품 가격은 0 이상이어야 합니다."),
+    INVALID_TOTAL_SOLD_COUNT(HttpStatus.BAD_REQUEST, "판매량은 0 이상이어야 합니다."),
+    INVALID_SALE_DATE(HttpStatus.BAD_REQUEST, "판매 일자가 유효하지 않습니다."),
+    INVALID_SALES_AMOUNT(HttpStatus.BAD_REQUEST, "판매 금액이 유효하지 않습니다."),
 
     // Balance
     INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "잔액이 부족합니다."),
@@ -22,18 +29,32 @@ public enum ErrorType {
     COUPON_ALREADY_ISSUED(HttpStatus.CONFLICT, "이미 발급된 쿠폰입니다."),
     COUPON_ALREADY_USED(HttpStatus.CONFLICT, "이미 사용된 쿠폰입니다."),
     UNAUTHORIZED_COUPON_ACCESS(HttpStatus.FORBIDDEN, "해당 쿠폰에 접근할 수 없습니다."),
+    INVALID_COUPON_ISSUE_DATA(HttpStatus.BAD_REQUEST, "쿠폰 발급 이력 생성 정보가 유효하지 않습니다."),
+    INVALID_COUPON_STATUS(HttpStatus.BAD_REQUEST, "쿠폰 상태 정보가 누락되었거나 잘못되었습니다."),
+    INVALID_COUPON_NAME(HttpStatus.BAD_REQUEST, "쿠폰 이름은 필수입니다."),
+    INVALID_COUPON_DISCOUNT_TYPE(HttpStatus.BAD_REQUEST, "할인 타입이 지정되지 않았습니다."),
+    INVALID_COUPON_QUANTITY(HttpStatus.BAD_REQUEST, "쿠폰 발급 수량은 1 이상이어야 합니다."),
+    INVALID_COUPON_DATE_RANGE(HttpStatus.BAD_REQUEST, "쿠폰 유효 기간이 올바르지 않습니다."),
+    INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "쿠폰 타입이 지정되지 않았습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),
     INVALID_ORDER_STATUS_TO_COMPLETE(HttpStatus.BAD_REQUEST, "결제 대기 상태에서만 주문을 완료할 수 있습니다."),
     INVALID_ORDER_STATUS_TO_CANCEL(HttpStatus.BAD_REQUEST, "결제 대기 상태에서만 주문을 취소할 수 있습니다."),
     INVALID_ORDER_STATUS_TO_EXPIRE(HttpStatus.BAD_REQUEST, "결제 대기 상태에서만 주문을 만료처리 할 수 있습니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "잘못된 사용자 ID입니다."),
+    INVALID_ORDER_DATE(HttpStatus.BAD_REQUEST, "주문 날짜가 유효하지 않습니다."),
+    INVALID_ORDER_TOTAL_AMOUNT(HttpStatus.BAD_REQUEST, "총 주문 금액이 잘못되었습니다."),
+    INVALID_ORDER_FINAL_AMOUNT(HttpStatus.BAD_REQUEST, "최종 결제 금액이 잘못되었습니다."),
+    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 유효하지 않습니다."),
 
     // Payment
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보가 존재하지 않습니다."),
     INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "결제 금액은 0 이상이어야 합니다."),
     INVALID_PAYMENT_STATUS_TO_COMPLETE(HttpStatus.BAD_REQUEST, "PENDING 상태에서 완료 처리할 수 있습니다."),
-    INVALID_PAYMENT_STATUS_TO_FAIL(HttpStatus.BAD_REQUEST, "PENDING 상태에서 실패 처리할 수 있습니다.")
+    INVALID_PAYMENT_STATUS_TO_FAIL(HttpStatus.BAD_REQUEST, "PENDING 상태에서 실패 처리할 수 있습니다."),
+    INVALID_PAYMENT_ORDER_ID(HttpStatus.BAD_REQUEST, "결제에 필요한 주문 ID가 누락되었습니다."),
+    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "결제 상태 정보가 누락되었거나 잘못되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/test/java/com/hhplusecommerce/application/payment/PaymentFacadeTest.java
+++ b/src/test/java/com/hhplusecommerce/application/payment/PaymentFacadeTest.java
@@ -65,7 +65,7 @@ class PaymentFacadeTest {
         PaymentResult result = paymentFacade.completePayment(command);
 
         // then
-        verify(balanceService).deductBalance(eq(USER_ID), any(BalanceCommand.class));
+        verify(balanceService).deductBalance(any(BalanceCommand.class));
         verify(inventoryService).decreaseStocks(orderItems);
         verify(order).complete();
         verify(paymentService).completePayment(ORDER_ID, FINAL_AMOUNT);
@@ -86,7 +86,7 @@ class PaymentFacadeTest {
 
         // 잔액 부족
         doThrow(new CustomException(ErrorType.INSUFFICIENT_BALANCE))
-                .when(balanceService).deductBalance(eq(USER_ID), any(BalanceCommand.class));
+                .when(balanceService).deductBalance(any(BalanceCommand.class));
 
         // when & then
         assertThatThrownBy(() -> paymentFacade.completePayment(command))

--- a/src/test/java/com/hhplusecommerce/domain/balance/BalanceHistoryTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/balance/BalanceHistoryTest.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BalanceHistoryTest {
 
@@ -42,7 +41,7 @@ class BalanceHistoryTest {
 
         @Test
         void 기존_잔액과_차감하려는_잔액이_동일하면_변경액은_0이며_예외없이_생성된다() {
-            BalanceHistory history = BalanceHistory.create(USER_ID, BEFORE_BALANCE, BEFORE_BALANCE, CHARGE);
+            BalanceHistory history = BalanceHistory.create(USER_ID, BEFORE_BALANCE, BEFORE_BALANCE, BalanceChangeType.CHARGE);
             assertThat(history.getAmount()).isEqualTo(BigDecimal.ZERO);
         }
     }

--- a/src/test/java/com/hhplusecommerce/domain/coupon/CouponHistoryTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/coupon/CouponHistoryTest.java
@@ -1,6 +1,7 @@
 package com.hhplusecommerce.domain.coupon;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -18,7 +19,7 @@ class CouponHistoryTest {
     private static final LocalDate VALID_END_DATE = LocalDate.now().plusDays(7);
 
     private Coupon createValidCoupon() {
-        return Coupon.builder()
+        Coupon coupon = Coupon.builder()
                 .couponName(COUPON_NAME)
                 .discountType(FIXED_RATE)
                 .discountValue(DISCOUNT_PERCENT_10)
@@ -28,6 +29,9 @@ class CouponHistoryTest {
                 .issuedQuantity(0)
                 .couponType(CouponType.LIMITED)
                 .build();
+
+        ReflectionTestUtils.setField(coupon, "id", 1L); // ID 수동 세팅
+        return coupon;
     }
 
     @Test

--- a/src/test/java/com/hhplusecommerce/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/coupon/CouponServiceTest.java
@@ -58,6 +58,8 @@ class CouponServiceTest {
                 .issuedQuantity(0)
                 .couponType(CouponType.LIMITED)  // 기본적으로 LIMITED로 설정
                 .build();
+
+        ReflectionTestUtils.setField(coupon, "id", COUPON_ID);
     }
 
     @Nested

--- a/src/test/java/com/hhplusecommerce/domain/coupon/CouponTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/coupon/CouponTest.java
@@ -32,6 +32,7 @@ class CouponTest {
                 .validStartDate(START)
                 .validEndDate(END)
                 .issuedQuantity(0)
+                .couponType(CouponType.LIMITED)
                 .build();
     }
 
@@ -48,6 +49,7 @@ class CouponTest {
                     .validStartDate(START)
                     .validEndDate(END)
                     .issuedQuantity(0)
+                    .couponType(CouponType.LIMITED)
                     .build())
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorType.INVALID_COUPON_VALUE.getMessage());
@@ -63,6 +65,7 @@ class CouponTest {
                     .validStartDate(START)
                     .validEndDate(END)
                     .issuedQuantity(0)
+                    .couponType(CouponType.LIMITED)
                     .build())
                     .isInstanceOf(CustomException.class);
         }
@@ -85,6 +88,7 @@ class CouponTest {
                     .validStartDate(START)
                     .validEndDate(END)
                     .issuedQuantity(0)
+                    .couponType(CouponType.LIMITED)
                     .build();
 
             assertThat(validCoupon.isAvailable()).isTrue();
@@ -100,6 +104,7 @@ class CouponTest {
                     .validStartDate(EXPIRED_START)
                     .validEndDate(EXPIRED_END)
                     .issuedQuantity(0)
+                    .couponType(CouponType.LIMITED)
                     .build();
 
             assertThat(expiredCoupon.isAvailable()).isFalse();
@@ -122,6 +127,7 @@ class CouponTest {
                     .validStartDate(START)
                     .validEndDate(END)
                     .issuedQuantity(0)
+                    .couponType(CouponType.LIMITED)
                     .build();
 
             coupon.increaseIssuedQuantity();
@@ -139,6 +145,7 @@ class CouponTest {
                     .validStartDate(START)
                     .validEndDate(END)
                     .issuedQuantity(0)
+                    .couponType(CouponType.LIMITED)
                     .build();
 
             coupon.increaseIssuedQuantity();
@@ -146,161 +153,6 @@ class CouponTest {
             assertThatThrownBy(coupon::increaseIssuedQuantity)
                     .isInstanceOf(CustomException.class)
                     .hasMessage(ErrorType.COUPON_ISSUE_LIMIT_EXCEEDED.getMessage());
-        }
-    }
-
-    @Nested
-    class 할인계산 {
-
-        private static final BigDecimal FIXED_DISCOUNT_500_WON = BigDecimal.valueOf(500);
-        private static final BigDecimal ORDER_TOTAL_400_WON = BigDecimal.valueOf(400);
-        private static final BigDecimal ZERO_AMOUNT = BigDecimal.ZERO;
-
-        @Test
-        void 정액_할인은_총금액을_초과하지_않는다() {
-            Coupon coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(FIXED_DISCOUNT_500_WON)
-                    .maxQuantity(MAX_QUANTITY)
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(0)
-                    .build();
-
-            BigDecimal discount = coupon.discountFor(ORDER_TOTAL_400_WON);
-
-            assertThat(discount).isEqualTo(ORDER_TOTAL_400_WON); // 할인액은 주문 금액을 초과하지 않음
-        }
-
-        @Test
-        void 총금액이_0이면_할인금액은_0() {
-            Coupon coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(FIXED_DISCOUNT_500_WON)
-                    .maxQuantity(MAX_QUANTITY)
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(0)
-                    .build();
-
-            BigDecimal discount = coupon.discountFor(ZERO_AMOUNT);
-
-            assertThat(discount).isEqualTo(ZERO_AMOUNT);
-        }
-
-        @Test
-        void 총금액이_null이면_할인금액은_0() {
-            Coupon coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(FIXED_DISCOUNT_500_WON)
-                    .maxQuantity(MAX_QUANTITY)
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(0)
-                    .build();
-
-            BigDecimal discount = coupon.discountFor(null);
-
-            assertThat(discount).isEqualTo(ZERO_AMOUNT);
-        }
-    }
-
-    @Nested
-    class 쿠폰_발급 {
-
-        private Coupon coupon;
-
-        @BeforeEach
-        void setUp() {
-            coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(BigDecimal.valueOf(500))
-                    .maxQuantity(MAX_QUANTITY)
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(0)
-                    .build();
-        }
-
-        @Test
-        void 발급가능한_상태에서_발급을_처리하면_발급수량이_증가한다() {
-            coupon.confirmCouponIssue();
-
-            assertThat(coupon.getIssuedQuantity()).isEqualTo(1);
-        }
-
-        @Test
-        void 수량제한_쿠폰은_최대_발급수량에_도달하면_발급할_수_없다() {
-            coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(BigDecimal.valueOf(500))
-                    .maxQuantity(MAX_QUANTITY)
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(MAX_QUANTITY) // 이미 최대 발급 수량으로 설정
-                    .couponType(CouponType.LIMITED) // 수량 제한이 있는 쿠폰
-                    .build();
-
-            assertThatThrownBy(() -> coupon.confirmCouponIssue())
-                    .isInstanceOf(CustomException.class)
-
-                    .hasMessage(ErrorType.COUPON_ISSUE_LIMIT_EXCEEDED.getMessage());
-        }
-    }
-    @Nested
-    class 발급_가능_여부_판단 {
-
-        @Test
-        void 수량제한이_없는_쿠폰은_발급수량에_관계없이_발급가능하다() {
-            coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(BigDecimal.valueOf(500))
-                    .maxQuantity(MAX_QUANTITY)  // 최대 발급 수량 설정
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(0) // 발급 수량 0으로 설정
-                    .couponType(CouponType.UNLIMITED) // 수량 제한이 없는 무제한 쿠폰 설정
-                    .build();
-
-            assertThat(coupon.isIssuable()).isTrue(); // 발급 가능 여부 확인
-        }
-
-        @Test
-        void 수량제한이_있는_쿠폰에서_발급수량이_최대_수량에_도달한_경우_발급불가하다() {
-            coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(BigDecimal.valueOf(500))
-                    .maxQuantity(MAX_QUANTITY)  // 최대 발급 수량 설정
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(MAX_QUANTITY) // 이미 최대 발급 수량으로 설정
-                    .couponType(CouponType.LIMITED) // 수량 제한이 있는 쿠폰 설정
-                    .build();
-
-            assertThat(coupon.isIssuable()).isFalse();
-        }
-
-        @Test
-        void 무제한_쿠폰은_발급수량에_관계없이_발급가능하다() {
-            coupon = Coupon.builder()
-                    .couponName(NAME)
-                    .discountType(FIXED_AMOUNT)
-                    .discountValue(BigDecimal.valueOf(500))
-                    .maxQuantity(Integer.MAX_VALUE)
-                    .validStartDate(START)
-                    .validEndDate(END)
-                    .issuedQuantity(0)
-                    .couponType(CouponType.UNLIMITED)
-                    .build();
-
-            assertThat(coupon.isIssuable()).isTrue();
         }
     }
 }

--- a/src/test/java/com/hhplusecommerce/domain/order/OrderServiceTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/order/OrderServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -42,14 +43,9 @@ class OrderServiceTest {
 
     @BeforeEach
     void setUp() {
-        mockOrder = Order.builder()
-                .userId(USER_ID)
-                .couponIssueId(COUPON_ID)
-                .orderDate(LocalDateTime.now())
-                .totalAmount(TOTAL_AMOUNT)
-                .finalAmount(FINAL_AMOUNT)
-                .status(OrderStatus.PAYMENT_WAIT)
-                .build();
+        OrderCommand command = new OrderCommand(USER_ID, COUPON_ID, List.of());
+        mockOrder = Order.create(command, TOTAL_AMOUNT, FINAL_AMOUNT);
+        ReflectionTestUtils.setField(mockOrder, "status", OrderStatus.PAYMENT_WAIT);
     }
 
     @Test


### PR DESCRIPTION
### 📝 항해플러스 3주차 - 이동규 코치님 피드백 적용 내용

<br>

| 커밋 | 피드백 & 적용 내용 |
|------|---------------------|
| `1246d79` | **📝 피드백**<br>값을 꺼내와서 Service에서 계산하거나 if 조건 분기를 탄다면,<br>리팩토링할만한 부분은 없는지 생각해보세요.<br><br>**✅ 적용**<br> - 도메인 객체 또는 Enum 내부로 상태 판단 및 계산 로직 이동<br> - Service는 메시지 위임만 담당하도록 구조 개선 |
| `d6b75f6` | **📝 피드백**<br>유효성 검증은 각 객체의 생성자에서 수행하는 게 좋습니다.<br>그래야 불변식을 준수하기 수월합니다.<br><br>**✅ 적용**<br> - 도메인 클래스의 생성자 또는 정적 팩토리 메서드에서 유효성 검증 수행<br> - 이에 따른 테스트 코드 수정 |
| `cb9e882` | **🛠 구조 개선**<br>서비스 로직 간결화 및 도메인 책임 분리를 위한 리팩토링<br><br>**✅ 적용**<br> - `Order.create()` 내부에서 `OrderItem` 생성까지 처리하도록 변경<br> - 서비스 레이어는 메시지 전달만 담당하도록 단순화<br> - 테스트 코드도 정적 팩토리 방식으로 수정 |
| 🔍 비개발 피드백 | **📝 피드백**<br>왜 쿠폰을 다른 스텝으로 분리했을까요?<br>인터페이스로 추상화하고 테스트 대역으로도 개발이 가능하지 않을까요?<br><br>**✅ 이해한 내용**<br> - 쿠폰 서비스는 `Promotion` 인터페이스로 추상화 가능하고,<br> - 테스트 더블로도 주문 흐름 개발이 가능함을 이해했습니다.<br> - 과제에서 쿠폰을 별도 스텝으로 분리한 의도를 이했습니다. |
| 💡 기술 피드백 | **📝 피드백**<br>getUserCoupons()는 N+1 문제가 발생할 수 있는 코드 구조입니다.<br>couponId로 매핑 후 findByIn을 사용하거나,<br>JPQL로 한 번에 조회하도록 개선할 수 있습니다.<br><br>**✅ 이해한 내용**<br> - `couponRepository.findById()` 반복 호출 구조에서 N+1 이슈가 발생할 수 있음을 파악<br> - 4주차 DB 연동 시 `findByIdIn` 또는 `@Query`로 개선 예정입니다 |
| ⚙ 구조 & 동시성 피드백 | 📝 피드백<br> - Facade 분리는 적절하나, 트랜잭션 분리만으로는 동시성 문제 해결은 아님<br> - 현재 구조에서는 상태 선점(재고 선점)의 실익이 크지 않음<br> - 쿠폰 선착순 발급은 **비관적 락 / 낙관적 락 각각의 우려와 대응 방식을 리서치**해보면 좋음

