### PR TITLE
[STEP-09/10] 기본/심화 과제 - 동시성 이슈 DB Lock 적용 및 보고서 작성, Finalize

### DIFF
--- a/src/main/java/com/hhplusecommerce/comoon/MDCLoggingFilter.java
+++ b/src/main/java/com/hhplusecommerce/comoon/MDCLoggingFilter.java
@@ -1,0 +1,57 @@
+package com.hhplusecommerce.comoon;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@Order(1)
+public class MDCLoggingFilter implements Filter {
+
+    private static final String REQUEST_ID = "requestId";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String requestId = generateRequestId();
+        setRequestIdToMDC(requestId);
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        long startTime = System.currentTimeMillis();
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            logRequestInfo(httpRequest, requestId, duration);
+            clearMDC();
+        }
+    }
+
+    private String generateRequestId() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+
+    private void setRequestIdToMDC(String requestId) {
+        MDC.put(REQUEST_ID, requestId);
+    }
+
+    private void clearMDC() {
+        MDC.clear();
+    }
+
+    private void logRequestInfo(HttpServletRequest request, String requestId, long duration) {
+        log.info("[{}] {} {} ({}ms)",
+                requestId,
+                request.getMethod(),
+                request.getRequestURI(),
+                duration
+        );
+    }
+}

--- a/src/main/java/com/hhplusecommerce/comoon/OrderScheduler.java
+++ b/src/main/java/com/hhplusecommerce/comoon/OrderScheduler.java
@@ -1,0 +1,29 @@
+package com.hhplusecommerce.comoon;
+
+import com.hhplusecommerce.domain.order.OrderService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderScheduler {
+
+    private final OrderService orderService;
+
+    /**
+     * 매 1분마다 실행되는 주문 만료 처리 스케줄러.
+     * 생성된 지 1~2분이 지난 대기 주문들을 만료 상태로 변경합니다.
+     */
+    @Scheduled(cron = "0 */1 * * * *")
+    public void expireUnpaidOrders() {
+        try {
+            log.info("[Scheduler] 결제 대기 주문 만료 처리 시작");
+            orderService.expireOverdueOrders();
+        } catch (Exception e) {
+            log.error("[Scheduler] 결제 대기 주문 만료 처리 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/hhplusecommerce/domain/balance/BalanceRepository.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/BalanceRepository.java
@@ -6,4 +6,9 @@ public interface BalanceRepository {
     Optional<UserBalance> findByUserId(Long userId);
 
     UserBalance save(UserBalance userBalance);
+
+    default UserBalance findOrCreateById(Long userId) {
+        return findByUserId(userId)
+                .orElseGet(() -> save(UserBalance.initialize(userId)));
+    }
 }

--- a/src/main/java/com/hhplusecommerce/domain/balance/UserBalance.java
+++ b/src/main/java/com/hhplusecommerce/domain/balance/UserBalance.java
@@ -23,6 +23,9 @@ public class UserBalance {
     private BigDecimal amount;
     private LocalDateTime updatedAt;
 
+    @Version
+    private Long version = 0L;
+
     @Builder
     public UserBalance(Long userId, BigDecimal amount) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) < 0) {

--- a/src/main/java/com/hhplusecommerce/domain/coupon/Coupon.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/Coupon.java
@@ -128,25 +128,16 @@ public class Coupon {
     }
 
     /**
-     * 쿠폰 발급 처리
-     * - 발급 가능 여부를 확인 후 수량 감소
-     * - 실제 사용자에게 발급된 쿠폰 이력은 CouponHistory에서 관리
+     * 쿠폰 발급 처리 (발급 가능 여부 판단 + 수량 증가를 원자적으로 수행)
+     * - 동시성 환경에서도 초과 발급 방지 보장
      */
     public void confirmCouponIssue() {
-        if (!isIssuable()) {
-            throw new CustomException(ErrorType.COUPON_ISSUE_LIMIT_EXCEEDED);
-        }
-        this.issuedQuantity++;
-    }
-
-    /**
-     * 쿠폰 발급 가능 여부 판단
-     */
-    public boolean isIssuable() {
-        if (couponType == CouponType.LIMITED) {
-            return this.issuedQuantity < this.maxQuantity;
+        if (this.couponType == CouponType.LIMITED) {
+            if (this.issuedQuantity + 1 > this.maxQuantity) {
+                throw new CustomException(ErrorType.COUPON_ISSUE_LIMIT_EXCEEDED);
+            }
         }
 
-        return true;
+        this.issuedQuantity += 1;
     }
 }

--- a/src/main/java/com/hhplusecommerce/domain/coupon/CouponRepository.java
+++ b/src/main/java/com/hhplusecommerce/domain/coupon/CouponRepository.java
@@ -1,8 +1,15 @@
 package com.hhplusecommerce.domain.coupon;
 
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface CouponRepository {
-    Optional<Coupon> findById(Long id);
+    Optional<Coupon> findById(@Param("id") Long id);
+
+    Optional<Coupon> findByIdForUpdate(Long id);
+
     Coupon save(Coupon coupon);
+
+    int issueCouponAtomically(Long couponId);
 }

--- a/src/main/java/com/hhplusecommerce/domain/order/OrderRepository.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/OrderRepository.java
@@ -8,5 +8,5 @@ public interface OrderRepository {
     Order save(Order order);
     Optional<Order> findById(Long id);
     Optional<Order> findByIdWithItems(Long orderId);
-    List<Order> findByStatusAndCreatedAtBefore(OrderStatus paymentWait, LocalDateTime thirtyMinutesAgo);
+    List<Order> findExpiredOrders(OrderStatus status, LocalDateTime expiredBefore);
 }

--- a/src/main/java/com/hhplusecommerce/domain/product/ProductInventoryRepository.java
+++ b/src/main/java/com/hhplusecommerce/domain/product/ProductInventoryRepository.java
@@ -7,4 +7,5 @@ public interface ProductInventoryRepository {
     Optional<ProductInventory> findInventoryByProductId(Long productId);
     List<ProductInventory> findAllByProductIdIn(List<Long> productIds);
     ProductInventory save(ProductInventory inventory);
+    Optional<ProductInventory> findByProductIdForUpdate(Long productId);
 }

--- a/src/main/java/com/hhplusecommerce/domain/product/ProductInventoryService.java
+++ b/src/main/java/com/hhplusecommerce/domain/product/ProductInventoryService.java
@@ -6,6 +6,7 @@ import com.hhplusecommerce.support.exception.CustomException;
 import com.hhplusecommerce.support.exception.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -54,8 +55,12 @@ public class ProductInventoryService {
      */
     @Transactional
     public void decreaseStock(Long productId, int quantity) {
-        ProductInventory inventory = productInventoryRepository.findInventoryByProductId(productId)
-                .orElseThrow(() -> new CustomException(ErrorType.PRODUCT_NOT_FOUND));
+        ProductInventory inventory = productInventoryRepository.findByProductIdForUpdate(productId)
+                .orElseThrow(() -> new CustomException(ErrorType.NOT_FOUND_PRODUCT_INVENTORY));
+
+        if (inventory.getStock() < quantity) {
+            throw new CustomException(ErrorType.INSUFFICIENT_STOCK);
+        }
 
         inventory.decrease(quantity);
     }

--- a/src/main/java/com/hhplusecommerce/infrastructure/coupon/CouponJpaRepository.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/coupon/CouponJpaRepository.java
@@ -1,7 +1,25 @@
 package com.hhplusecommerce.infrastructure.coupon;
 
 import com.hhplusecommerce.domain.coupon.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :couponId")
+    Optional<Coupon> findByIdForUpdate(@Param("couponId") Long couponId);
+
+    @Modifying
+    @Query("""
+        UPDATE Coupon c
+        SET c.issuedQuantity = c.issuedQuantity + 1
+        WHERE c.id = :couponId AND c.issuedQuantity < c.maxQuantity
+    """)
+    int issueCouponAtomically(@Param("couponId") Long couponId);
 }

--- a/src/main/java/com/hhplusecommerce/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/coupon/CouponRepositoryImpl.java
@@ -2,7 +2,12 @@ package com.hhplusecommerce.infrastructure.coupon;
 
 import com.hhplusecommerce.domain.coupon.Coupon;
 import com.hhplusecommerce.domain.coupon.CouponRepository;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -19,7 +24,17 @@ public class CouponRepositoryImpl implements CouponRepository {
     }
 
     @Override
+    public Optional<Coupon> findByIdForUpdate(Long id) {
+        return couponJpaRepository.findByIdForUpdate(id);
+    }
+
+    @Override
     public Coupon save(Coupon coupon) {
         return couponJpaRepository.save(coupon);
+    }
+
+    @Override
+    public int issueCouponAtomically(Long couponId) {
+        return couponJpaRepository.issueCouponAtomically(couponId);
     }
 }

--- a/src/main/java/com/hhplusecommerce/infrastructure/order/OrderJpaRepository.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/order/OrderJpaRepository.java
@@ -11,8 +11,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
-    List<Order> findByOrderStatusAndCreatedAtBefore(OrderStatus status, LocalDateTime time);
 
     @Query("SELECT o FROM Order o JOIN FETCH o.orderItems WHERE o.id = :orderId")
     Optional<Order> findByIdWithItems(@Param("orderId") Long orderId);
+
+    @Query("SELECT o FROM Order o WHERE o.orderStatus = :orderStatus AND o.createdAt <= :expiredBefore")
+    List<Order> findExpiredOrders(@Param("orderStatus") OrderStatus orderStatus,
+                                  @Param("expiredBefore") LocalDateTime expiredBefore);
 }

--- a/src/main/java/com/hhplusecommerce/infrastructure/order/OrderRepositoryImpl.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/order/OrderRepositoryImpl.java
@@ -32,7 +32,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public List<Order> findByStatusAndCreatedAtBefore(OrderStatus status, LocalDateTime time) {
-        return orderJpaRepository.findByOrderStatusAndCreatedAtBefore(status, time);
+    public List<Order> findExpiredOrders(OrderStatus status, LocalDateTime from, LocalDateTime to) {
+        return orderJpaRepository.findByOrderStatusAndCreatedAtBetween(status, from, to);
     }
 }

--- a/src/main/java/com/hhplusecommerce/infrastructure/order/OrderRepositoryImpl.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/order/OrderRepositoryImpl.java
@@ -32,7 +32,7 @@ public class OrderRepositoryImpl implements OrderRepository {
     }
 
     @Override
-    public List<Order> findExpiredOrders(OrderStatus status, LocalDateTime from, LocalDateTime to) {
-        return orderJpaRepository.findByOrderStatusAndCreatedAtBetween(status, from, to);
+    public List<Order> findExpiredOrders(OrderStatus status, LocalDateTime expiredBefore) {
+        return orderJpaRepository.findExpiredOrders(status, expiredBefore);
     }
 }

--- a/src/main/java/com/hhplusecommerce/infrastructure/product/ProductInventoryJpaRepository.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/product/ProductInventoryJpaRepository.java
@@ -1,7 +1,11 @@
 package com.hhplusecommerce.infrastructure.product;
 
 import com.hhplusecommerce.domain.product.ProductInventory;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +14,8 @@ public interface ProductInventoryJpaRepository extends JpaRepository<ProductInve
 
     Optional<ProductInventory> findByProductId(Long productId);
     List<ProductInventory> findAllByProduct_IdIn(List<Long> productIds);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT pi FROM ProductInventory pi WHERE pi.product.id = :productId")
+    Optional<ProductInventory> findByProductIdForUpdate(@Param("productId") Long productId);
 }

--- a/src/main/java/com/hhplusecommerce/infrastructure/product/ProductInventoryRepositoryImpl.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/product/ProductInventoryRepositoryImpl.java
@@ -28,4 +28,9 @@ public class ProductInventoryRepositoryImpl implements ProductInventoryRepositor
     public ProductInventory save(ProductInventory inventory) {
         return productInventoryJpaRepository.save(inventory);
     }
+
+    @Override
+    public Optional<ProductInventory> findByProductIdForUpdate(Long productId) {
+        return productInventoryJpaRepository.findByProductIdForUpdate(productId);
+    }
 }

--- a/src/main/java/com/hhplusecommerce/support/exception/ErrorType.java
+++ b/src/main/java/com/hhplusecommerce/support/exception/ErrorType.java
@@ -14,6 +14,7 @@ public enum ErrorType {
     INVALID_TOTAL_SOLD_COUNT(HttpStatus.BAD_REQUEST, "판매량은 0 이상이어야 합니다."),
     INVALID_SALE_DATE(HttpStatus.BAD_REQUEST, "판매 일자가 유효하지 않습니다."),
     INVALID_SALES_AMOUNT(HttpStatus.BAD_REQUEST, "판매 금액이 유효하지 않습니다."),
+    NOT_FOUND_PRODUCT_INVENTORY(HttpStatus.NOT_FOUND, "해당 상품의 재고 정보를 찾을 수 없습니다."),
 
     // Balance
     INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "잔액이 부족합니다."),
@@ -36,6 +37,7 @@ public enum ErrorType {
     INVALID_COUPON_QUANTITY(HttpStatus.BAD_REQUEST, "쿠폰 발급 수량은 1 이상이어야 합니다."),
     INVALID_COUPON_DATE_RANGE(HttpStatus.BAD_REQUEST, "쿠폰 유효 기간이 올바르지 않습니다."),
     INVALID_COUPON_TYPE(HttpStatus.BAD_REQUEST, "쿠폰 타입이 지정되지 않았습니다."),
+    COUPON_ISSUE_FAILED(HttpStatus.BAD_REQUEST, "쿠폰 발급에 실패했습니다."),
 
     // Order
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문이 존재하지 않습니다."),
@@ -54,7 +56,10 @@ public enum ErrorType {
     INVALID_PAYMENT_STATUS_TO_COMPLETE(HttpStatus.BAD_REQUEST, "PENDING 상태에서 완료 처리할 수 있습니다."),
     INVALID_PAYMENT_STATUS_TO_FAIL(HttpStatus.BAD_REQUEST, "PENDING 상태에서 실패 처리할 수 있습니다."),
     INVALID_PAYMENT_ORDER_ID(HttpStatus.BAD_REQUEST, "결제에 필요한 주문 ID가 누락되었습니다."),
-    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "결제 상태 정보가 누락되었거나 잘못되었습니다.")
+    INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "결제 상태 정보가 누락되었거나 잘못되었습니다."),
+
+    // Concurrency
+    CONCURRENT_TRANSACTION_EXCEPTION(HttpStatus.CONFLICT, "동시성 오류가 발생했습니다. 다시 시도해 주세요.")
     ;
 
     private final HttpStatus status;

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <!-- Console appender to print logs to the console -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Setting root log level to INFO to reduce log verbosity -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <!-- Setting specific logger for your package (com.hhplusecommerce) to INFO level -->
+    <logger name="com.hhplusecommerce" level="INFO"/>
+
+    <!-- Hibernate SQL logging set to WARN to avoid excessive logging of SQL queries -->
+    <logger name="org.hibernate.SQL" level="WARN"/>
+    <logger name="org.hibernate.type" level="WARN"/>
+
+</configuration>

--- a/src/test/java/com/hhplusecommerce/ConcurrencyTestSupport.java
+++ b/src/test/java/com/hhplusecommerce/ConcurrencyTestSupport.java
@@ -1,0 +1,59 @@
+package com.hhplusecommerce;
+
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+/**
+ * 동시성 테스트용 서포트 클래스
+ */
+@Slf4j
+public abstract class ConcurrencyTestSupport extends IntegrationTestSupport {
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @AfterEach
+    void tearDown() {
+        dbCleaner.execute();
+        log.info("테스트 후 DB 초기화 완료");
+    }
+
+    /**
+     * 동일한 Runnable을 여러 쓰레드로 동시에 실행
+     */
+    protected void executeConcurrency(int threadCount, Runnable runnable) {
+        List<Runnable> runnables = IntStream.range(0, threadCount)
+                .mapToObj(i -> runnable)
+                .toList();
+        executeConcurrency(runnables);
+    }
+
+    /**
+     * 주어진 Runnable 리스트를 각각 병렬로 실행
+     */
+    protected void executeConcurrency(List<Runnable> runnables) {
+        ExecutorService executorService = Executors.newFixedThreadPool(runnables.size());
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (Runnable runnable : runnables) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    runnable.run();
+                } catch (Exception e) {
+                    log.error("스레드 실행 중 오류 발생: {}", e.getMessage());
+                }
+            }, executorService));
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        executorService.shutdown();
+    }
+}

--- a/src/test/java/com/hhplusecommerce/concurrency/balance/BalanceConcurrencyTest.java
+++ b/src/test/java/com/hhplusecommerce/concurrency/balance/BalanceConcurrencyTest.java
@@ -1,0 +1,291 @@
+package com.hhplusecommerce.concurrency.balance;
+
+import com.hhplusecommerce.ConcurrencyTestSupport;
+import com.hhplusecommerce.domain.balance.BalanceCommand;
+import com.hhplusecommerce.domain.balance.BalanceRepository;
+import com.hhplusecommerce.domain.balance.BalanceService;
+import com.hhplusecommerce.domain.balance.UserBalance;
+import com.hhplusecommerce.support.exception.CustomException;
+import jakarta.persistence.OptimisticLockException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+class BalanceConcurrencyTest extends ConcurrencyTestSupport {
+
+    @Autowired
+    private BalanceService balanceService;
+
+    @Autowired
+    private BalanceRepository balanceRepository;
+
+    private static final Long USER_ID = 1L;
+    private static final BigDecimal INITIAL_BALANCE = BigDecimal.valueOf(10000);
+    private static final BigDecimal CHARGE_AMOUNT = BigDecimal.valueOf(1000);
+    private static final int CONCURRENCY_THREADS = 2;
+    private static final BigDecimal EXPECTED_AMOUNT = INITIAL_BALANCE.add(CHARGE_AMOUNT); // 하나만 성공
+
+    @BeforeEach
+    void setUp() {
+        balanceRepository.save(UserBalance.create(USER_ID, INITIAL_BALANCE));
+        log.info("테스트 시작 전 사용자 {}의 잔액 초기화: {}", USER_ID, INITIAL_BALANCE.toPlainString());
+    }
+
+    @Nested
+    class 잔액_충전_동시성 {
+
+        @Test
+        void 동시에_충전_요청_시_하나만_성공한다() throws InterruptedException {
+            CountDownLatch startSignal = new CountDownLatch(1);
+            CountDownLatch doneSignal = new CountDownLatch(CONCURRENCY_THREADS);
+            AtomicInteger successCount = new AtomicInteger();
+
+            Runnable task = () -> {
+                try {
+                    startSignal.await();
+                    balanceService.chargeBalance(new BalanceCommand(USER_ID, CHARGE_AMOUNT));
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+                    log.warn("낙관적 락 충돌로 충전 실패");
+                } catch (Exception e) {
+                    log.error("예외 발생", e);
+                } finally {
+                    doneSignal.countDown();
+                }
+            };
+
+            ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENCY_THREADS);
+            for (int i = 0; i < CONCURRENCY_THREADS; i++) {
+                executorService.submit(task);
+            }
+
+            startSignal.countDown();
+            doneSignal.await();
+
+            Optional<UserBalance> result = balanceRepository.findByUserId(USER_ID);
+            Assertions.assertTrue(result.isPresent(), "잔액 정보가 존재해야 합니다.");
+
+            BigDecimal finalBalance = result.get().getAmount();
+
+            log.warn("▶ 최종 잔액: {}", finalBalance.stripTrailingZeros().toPlainString());
+            log.warn("▶ 예상 최종 잔액: {}", EXPECTED_AMOUNT.stripTrailingZeros().toPlainString());
+            log.warn("▶ 성공한 충전 횟수: {}", successCount.get());
+
+            Assertions.assertEquals(1, successCount.get(), "충전은 한 번만 성공해야 합니다.");
+            Assertions.assertEquals(EXPECTED_AMOUNT.stripTrailingZeros().toPlainString(), finalBalance.stripTrailingZeros().toPlainString(), "충전된 금액이 예상과 다릅니다.");
+        }
+    }
+
+    @Nested
+    class 잔액_차감_동시성 {
+
+        private static final BigDecimal INITIAL_AMOUNT = BigDecimal.valueOf(5000);
+        private static final BigDecimal DEDUCT_AMOUNT = BigDecimal.valueOf(3000);
+
+        @BeforeEach
+        void setUpDeduct() {
+            balanceRepository.save(UserBalance.create(USER_ID, INITIAL_AMOUNT));
+            log.info("차감 테스트 시작 전 사용자 {}의 잔액 초기화: {}", USER_ID, INITIAL_AMOUNT.toPlainString());
+        }
+
+        @Test
+        void 동시에_차감_요청_시_하나만_성공한다() throws InterruptedException {
+            CountDownLatch startSignal = new CountDownLatch(1);
+            CountDownLatch doneSignal = new CountDownLatch(CONCURRENCY_THREADS);
+            AtomicInteger successCount = new AtomicInteger();
+
+            Runnable task = () -> {
+                try {
+                    startSignal.await();
+                    balanceService.deductBalance(new BalanceCommand(USER_ID, DEDUCT_AMOUNT));
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+                    log.warn("낙관적 락 충돌로 차감 실패");
+                } catch (Exception e) {
+                    log.error("예외 발생", e);
+                } finally {
+                    doneSignal.countDown();
+                }
+            };
+
+            ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENCY_THREADS);
+            for (int i = 0; i < CONCURRENCY_THREADS; i++) {
+                executorService.submit(task);
+            }
+
+            startSignal.countDown();
+            doneSignal.await();
+
+            Optional<UserBalance> result = balanceRepository.findByUserId(USER_ID);
+            Assertions.assertTrue(result.isPresent(), "잔액 정보가 존재해야 합니다.");
+
+            BigDecimal finalBalance = result.get().getAmount();
+            BigDecimal expectedBalance = INITIAL_AMOUNT.subtract(DEDUCT_AMOUNT);
+
+            log.warn("▶ 최종 잔액: {}", finalBalance.stripTrailingZeros().toPlainString());
+            log.warn("▶ 예상 최종 잔액: {}", expectedBalance.stripTrailingZeros().toPlainString());
+            log.warn("▶ 성공한 차감 횟수: {}", successCount.get());
+
+            Assertions.assertEquals(1, successCount.get(), "차감은 한 번만 성공해야 합니다.");
+            Assertions.assertEquals(expectedBalance.stripTrailingZeros().toPlainString(), finalBalance.stripTrailingZeros().toPlainString(), "차감된 금액이 예상과 다릅니다.");
+        }
+    }
+
+    @Nested
+    class 잔액_순차_요청_정합성_테스트  {
+
+        private static final BigDecimal INITIAL_BALANCE = BigDecimal.valueOf(500);
+        private static final BigDecimal CHARGE_AMOUNT = BigDecimal.valueOf(1000);
+        private static final BigDecimal EXPECTED_BALANCE_AFTER_BOTH = BigDecimal.valueOf(500); // 충전 -> 차감
+        private static final BigDecimal EXPECTED_BALANCE_AFTER_CHARGE_ONLY = BigDecimal.valueOf(1500); // 차감 실패 -> 충전
+
+        @Test
+        void 충전_후_차감_순서로_요청하면_정상적으로_잔액이_감소한다() {
+            // given
+            balanceRepository.save(UserBalance.create(USER_ID, INITIAL_BALANCE));
+
+            // when
+            balanceService.chargeBalance(new BalanceCommand(USER_ID, CHARGE_AMOUNT));
+            balanceService.deductBalance(new BalanceCommand(USER_ID, CHARGE_AMOUNT));
+
+            // then
+            BigDecimal result = balanceRepository.findByUserId(USER_ID).get().getAmount();
+            String formattedAmount = result.stripTrailingZeros().toPlainString();
+
+            log.info("최종 잔액: {}", formattedAmount);
+
+            if (result.compareTo(EXPECTED_BALANCE_AFTER_BOTH) == 0) {
+                log.info("정상 케이스 1 - 충전 후 차감이 성공한 시나리오 (잔액: {})", formattedAmount);
+            } else {
+                log.warn("예기치 않은 결과 - 잔액: {}", formattedAmount);
+            }
+
+            Assertions.assertEquals(EXPECTED_BALANCE_AFTER_BOTH.stripTrailingZeros().toPlainString(),
+                    result.stripTrailingZeros().toPlainString(),
+                    "충전 후 차감 시 잔액이 기대와 다릅니다.");
+        }
+
+        @Test
+        void 차감_후_충전_순서로_요청하면_차감은_실패하고_충전만_성공한다() {
+            // given
+            balanceRepository.save(UserBalance.create(USER_ID, INITIAL_BALANCE));
+
+            // when
+            Assertions.assertThrows(CustomException.class, () ->
+                    balanceService.deductBalance(new BalanceCommand(USER_ID, CHARGE_AMOUNT))
+            );
+            balanceService.chargeBalance(new BalanceCommand(USER_ID, CHARGE_AMOUNT));
+
+            // then
+            BigDecimal result = balanceRepository.findByUserId(USER_ID).get().getAmount();
+            String formattedAmount = result.stripTrailingZeros().toPlainString();
+
+            log.info("최종 잔액: {}", formattedAmount);
+
+            if (result.compareTo(EXPECTED_BALANCE_AFTER_CHARGE_ONLY) == 0) {
+                log.info("정상 케이스 2 - 차감 실패 후 충전만 성공한 시나리오 (잔액: {})", formattedAmount);
+            } else {
+                log.warn("예기치 않은 결과 - 잔액: {}", formattedAmount);
+            }
+
+            Assertions.assertEquals(EXPECTED_BALANCE_AFTER_CHARGE_ONLY.stripTrailingZeros().toPlainString(),
+                    formattedAmount,
+                    "차감 실패 후 충전만 성공한 경우 잔액이 기대와 다릅니다.");
+        }
+    }
+
+    @Nested
+    class 충전_차감_동시_요청 {
+
+        /**
+         * 현재 잔액이 500원일 때,
+         * 충전과 차감을 동시에 요청하면 실행 순서에 따라 다음 두 가지 정상 결과 중 하나가 발생한다.
+         * <p>
+         * 1. 충전이 먼저 → 차감도 성공 → 최종 잔액: 500원
+         * 2. 차감이 먼저 → 실패 + 충전만 성공 → 최종 잔액: 1500원
+         * <p>
+         * 이 외의 결과는 중복 처리 또는 동시성 문제로 간주한다.
+         */
+        private static final BigDecimal INITIAL_BALANCE = BigDecimal.valueOf(500);
+        private static final BigDecimal AMOUNT = BigDecimal.valueOf(1000);
+
+        @BeforeEach
+        void initBalance() {
+            balanceRepository.save(UserBalance.create(USER_ID, INITIAL_BALANCE));
+        }
+
+        @Test
+        void 충전과_차감을_랜덤_순서로_요청하면_정합성이_유지되어야_한다() throws InterruptedException {
+            CountDownLatch startSignal = new CountDownLatch(1);
+            CountDownLatch doneSignal = new CountDownLatch(CONCURRENCY_THREADS);
+            AtomicInteger chargeSuccess = new AtomicInteger();
+            AtomicInteger deductSuccess = new AtomicInteger();
+
+            Runnable chargeTask = () -> {
+                try {
+                    startSignal.await();
+                    balanceService.chargeBalance(new BalanceCommand(USER_ID, AMOUNT));
+                    chargeSuccess.incrementAndGet();
+                } catch (Exception e) {
+                    log.warn("충전 실패: {}", e.getMessage());
+                } finally {
+                    doneSignal.countDown();
+                }
+            };
+
+            Runnable deductTask = () -> {
+                try {
+                    startSignal.await();
+                    balanceService.deductBalance(new BalanceCommand(USER_ID, AMOUNT));
+                    deductSuccess.incrementAndGet();
+                } catch (Exception e) {
+                    log.warn("차감 실패: {}", e.getMessage());
+                } finally {
+                    doneSignal.countDown();
+                }
+            };
+
+            ExecutorService executor = Executors.newFixedThreadPool(CONCURRENCY_THREADS);
+
+            List<Runnable> tasks = new ArrayList<>(List.of(chargeTask, deductTask));
+            Collections.shuffle(tasks); // 매번 다른 순서
+
+            tasks.forEach(executor::submit);
+
+            startSignal.countDown();
+            doneSignal.await();
+
+            BigDecimal finalBalance = balanceRepository.findByUserId(USER_ID)
+                    .orElseThrow(() -> new IllegalStateException("잔액 정보 없음"))
+                    .getAmount();
+
+            int charge = chargeSuccess.get();
+            int deduct = deductSuccess.get();
+
+            log.info("충전 성공 횟수: {}", charge);
+            log.info("차감 성공 횟수: {}", deduct);
+            log.info("최종 잔액: {}", finalBalance.stripTrailingZeros().toPlainString());
+
+            boolean case1 = charge == 1 && deduct == 1 && finalBalance.compareTo(INITIAL_BALANCE) == 0;
+            boolean case2 = charge == 1 && deduct == 0 && finalBalance.compareTo(INITIAL_BALANCE.add(AMOUNT)) == 0;
+
+            Assertions.assertTrue(case1 || case2,
+                    String.format("정합성 실패 - 충전: %d, 차감: %d, 잔액: %s", charge, deduct, finalBalance.stripTrailingZeros().toPlainString()));
+        }
+    }
+}

--- a/src/test/java/com/hhplusecommerce/concurrency/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/com/hhplusecommerce/concurrency/coupon/CouponConcurrencyTest.java
@@ -1,0 +1,148 @@
+package com.hhplusecommerce.concurrency.coupon;
+
+import com.hhplusecommerce.ConcurrencyTestSupport;
+import com.hhplusecommerce.domain.coupon.Coupon;
+import com.hhplusecommerce.domain.coupon.CouponCommand;
+import com.hhplusecommerce.domain.coupon.CouponRepository;
+import com.hhplusecommerce.domain.coupon.CouponService;
+import lombok.extern.slf4j.Slf4j;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@Slf4j
+class CouponConcurrencyTest extends ConcurrencyTestSupport {
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    CouponService couponService;
+
+    @Nested
+    class 시나리오1_잔여수량_내_동시_요청 {
+
+        private static final int ALREADY_ISSUED = 490;
+        private static final int MAX = 500;
+        private static final int REQUEST_COUNT = 10;
+        private Coupon coupon;
+
+        @BeforeEach
+        void setUp() {
+            coupon = couponRepository.save(Instancio.of(Coupon.class)
+                    .set(field("couponName"), "잔여수량동시요청")
+                    .set(field("maxQuantity"), MAX)
+                    .set(field("issuedQuantity"), ALREADY_ISSUED)
+                    .create());
+        }
+
+        @Test
+        void 동시에_쿠폰_발급_요청_시_남은_쿠폰수량_만큼만_성공해야_한다() throws InterruptedException {
+            List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+            List<Boolean> successFlags = Collections.synchronizedList(new ArrayList<>());
+            CountDownLatch latch = new CountDownLatch(REQUEST_COUNT);
+
+            executeConcurrency(
+                    REQUEST_COUNT,
+                    () -> {
+                        try {
+                            couponService.issueCoupon(new CouponCommand(ThreadLocalRandom.current().nextLong(1, 1_000_000), coupon.getId()));
+                            successFlags.add(true);
+                        } catch (Throwable e) {
+                            successFlags.add(false);
+                            errors.add(e);
+                            log.warn("예외 발생: {}", e.getMessage(), e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
+            );
+
+            latch.await();
+
+            Coupon updated = couponRepository.findById(coupon.getId()).orElseThrow();
+            long successCount = successFlags.stream().filter(Boolean::booleanValue).count();
+            int failCount = (int) successFlags.stream().filter(flag -> !flag).count();
+
+            log.warn("🟢 [잔여수량 내 동시 요청 테스트 결과]");
+            log.warn("▶ 초기 발급 수량: {}, 최대 수량: {}", ALREADY_ISSUED, MAX);
+            log.warn("▶ 동시 요청 수: {}", REQUEST_COUNT);
+            log.warn("▶ 최종 발급 수량: {}", updated.getIssuedQuantity());
+            log.warn("▶ 성공 수: {}, 실패 수: {}", successCount, failCount);
+
+            assertThat(updated.getIssuedQuantity()).isEqualTo(MAX);
+            assertThat(successCount).isEqualTo(REQUEST_COUNT);
+            assertThat(failCount).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    class 시나리오2_잔여수량_없는_경우 {
+
+        private static final int MAX = 500;
+        private static final int ISSUED = 500;
+        private static final int THREAD_COUNT = 5;
+        private Coupon coupon;
+
+        @BeforeEach
+        void setUp() {
+            // 고유한 쿠폰 이름 사용 (중복 방지)
+            String uniqueName = "전량발급_" + System.nanoTime();
+            coupon = couponRepository.save(Instancio.of(Coupon.class)
+                    .set(field("couponName"), uniqueName)
+                    .set(field("maxQuantity"), MAX)
+                    .set(field("issuedQuantity"), ISSUED)
+                    .create());
+        }
+
+        @Test
+        void 전량발급_완료된_쿠폰에_동시요청시_모두_실패해야한다() throws InterruptedException {
+            List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+            List<Boolean> successFlags = Collections.synchronizedList(new ArrayList<>());
+            CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+            executeConcurrency(
+                    THREAD_COUNT,
+                    () -> {
+                        try {
+                            couponService.issueCoupon(new CouponCommand(1L, coupon.getId()));
+                            successFlags.add(true);
+                        } catch (Throwable e) {
+                            successFlags.add(false);
+                            errors.add(e);
+                            log.warn("예외 발생: {}", e.getMessage(), e);
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
+            );
+
+            latch.await();
+
+            Coupon updated = couponRepository.findById(coupon.getId()).orElseThrow();
+            long successCount = successFlags.stream().filter(Boolean::booleanValue).count();
+            int failCount = (int) successFlags.stream().filter(flag -> !flag).count();
+
+            log.warn("🔒 [전량 발급된 쿠폰 테스트 결과]");
+            log.warn("▶ 초기 발급 수량: {}, 최대 수량: {}", ISSUED, MAX);
+            log.warn("▶ 동시 요청 수: {}", THREAD_COUNT);
+            log.warn("▶ 최종 발급 수량: {}", updated.getIssuedQuantity());
+            log.warn("▶ 성공 수: {}, 실패 수: {}", successCount, failCount);
+
+            assertThat(updated.getIssuedQuantity()).isEqualTo(MAX);
+            assertThat(successCount).isEqualTo(0);
+            assertThat(failCount).isEqualTo(THREAD_COUNT);
+        }
+    }
+}

--- a/src/test/java/com/hhplusecommerce/concurrency/product/ProductInventoryConcurrencyTest.java
+++ b/src/test/java/com/hhplusecommerce/concurrency/product/ProductInventoryConcurrencyTest.java
@@ -1,0 +1,233 @@
+package com.hhplusecommerce.concurrency.product;
+
+import com.hhplusecommerce.ConcurrencyTestSupport;
+import com.hhplusecommerce.domain.product.*;
+import lombok.extern.slf4j.Slf4j;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@Slf4j
+class ProductInventoryConcurrencyTest extends ConcurrencyTestSupport {
+
+    @Autowired
+    ProductInventoryService inventoryService;
+
+    @Autowired
+    ProductInventoryRepository inventoryRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    private static final int THREAD_COUNT = 2; // 테스트에서 사용할 스레드 수
+    private static final int INITIAL_STOCK_1 = 1; // 시나리오 1의 초기 재고
+    private static final int INITIAL_STOCK_2 = 12; // 시나리오 2의 초기 재고
+    private static final int ORDER_QUANTITY_A = 10; // 시나리오 2에서 A가 주문할 수량
+    private static final int ORDER_QUANTITY_B = 5;  // 시나리오 2에서 B가 주문할 수량
+
+    @Nested
+    class 시나리오1_동일상품_재고가_1개만_남은_경우_동시_주문 {
+
+        private Product product;
+
+        @BeforeEach
+        void setUp() {
+            product = productRepository.save(Instancio.of(Product.class)
+                    .set(field("name"), "동시성테스트상품")
+                    .set(field("category"), "테스트")
+                    .set(field("price"), BigDecimal.valueOf(10000))
+                    .create());
+
+            inventoryRepository.save(ProductInventory.builder()
+                    .product(product)
+                    .stock(INITIAL_STOCK_1)
+                    .build());
+        }
+
+        @Test
+        void 동시에_주문시_1개만_성공하고_1개는_예외가_발생해야_한다() {
+            long productId = product.getId();
+            List<Throwable> errors = new ArrayList<>();
+
+            executeConcurrency(THREAD_COUNT, () -> {
+                try {
+                    Thread.sleep(100);
+                    inventoryService.decreaseStock(productId, 1);
+                } catch (Throwable e) {
+                    synchronized (errors) {
+                        errors.add(e);
+                    }
+                }
+            });
+
+            ProductInventory updated = inventoryRepository.findInventoryByProductId(productId).orElseThrow();
+
+            int expectedErrors = THREAD_COUNT - 1;
+
+            log.warn("\uD83D\uDCE6 [시나리오1 결과 - 재고 1개 상품에 2명 동시 주문 → 중복 차감 발생 여부]");
+            log.warn("▶ 초기 재고: {}", INITIAL_STOCK_1);
+            log.warn("▶ 동시 요청 수: {}", THREAD_COUNT);
+            log.warn("▶ 최종 재고: {}", updated.getStock());
+            log.warn("▶ 기대 예외 발생 수: {}", expectedErrors);
+            log.warn("▶ 실제 예외 발생 수: {}", errors.size());
+
+            assertThat(updated.getStock())
+                    .withFailMessage("재고는 정확히 0이어야 합니다. 하나만 차감되어야 합니다.")
+                    .isEqualTo(0);
+
+            assertThat(errors.size())
+                    .withFailMessage("두 번째 사용자의 요청은 예외가 발생했어야 합니다.")
+                    .isEqualTo(expectedErrors);
+        }
+    }
+
+    @Nested
+    class 시나리오2_재고는_12개인데_A는_10개_B는_5개를_동시에_주문하는_경우 {
+
+        private Product product;
+
+        @BeforeEach
+        void setUp() {
+            product = productRepository.save(Instancio.of(Product.class)
+                    .set(field("name"), "재고초과테스트")
+                    .set(field("category"), "테스트")
+                    .set(field("price"), BigDecimal.valueOf(10000))
+                    .create());
+
+            inventoryRepository.save(ProductInventory.builder()
+                    .product(product)
+                    .stock(INITIAL_STOCK_2)
+                    .build());
+        }
+
+        @Test
+        void 재고보다_많은_총_수량이_동시에_주문되면_하나는_실패해야_한다() throws InterruptedException {
+            long productId = product.getId();
+            List<Throwable> errors = new ArrayList<>();
+            CountDownLatch latch = new CountDownLatch(2);
+            int[] orderQuantities = {ORDER_QUANTITY_A, ORDER_QUANTITY_B};
+
+            executeConcurrency(
+                    List.of(
+                            () -> {
+                                try {
+                                    Thread.sleep(100);
+                                    inventoryService.decreaseStock(productId, orderQuantities[0]);
+                                } catch (Throwable e) {
+                                    synchronized (errors) {
+                                        errors.add(e);
+                                    }
+                                } finally {
+                                    latch.countDown();
+                                }
+                            },
+                            () -> {
+                                try {
+                                    Thread.sleep(100);
+                                    inventoryService.decreaseStock(productId, orderQuantities[1]);
+                                } catch (Throwable e) {
+                                    synchronized (errors) {
+                                        errors.add(e);
+                                    }
+                                } finally {
+                                    latch.countDown();
+                                }
+                            }
+                    )
+            );
+
+            latch.await();
+
+            ProductInventory updated = inventoryRepository.findInventoryByProductId(productId).orElseThrow();
+            int expectedErrors = THREAD_COUNT - 1;
+
+            log.warn("\uD83D\uDCE6 [시나리오2 결과 - 재고 12개 상품에 10개 & 5개 동시 주문 → 초과 주문 예외 발생 여부]");
+            log.warn("▶ 초기 재고: {}", INITIAL_STOCK_2);
+            log.warn("▶ 동시 요청 수: 2 (10개, 5개)");
+            log.warn("▶ 최종 재고: {}", updated.getStock());
+            log.warn("▶ 기대 예외 발생 수: {}", expectedErrors);
+            log.warn("▶ 실제 예외 발생 수: {}", errors.size());
+
+            assertThat(errors.size())
+                    .withFailMessage("하나의 주문은 실패했어야 합니다.")
+                    .isEqualTo(expectedErrors);
+        }
+    }
+
+    @Nested
+    class 시나리오3_랜덤한_다양한_수량_동시_주문 {
+
+        private Product product;
+        private static final int INITIAL_STOCK = 10;
+
+        @BeforeEach
+        void setUp() {
+            product = productRepository.save(Instancio.of(Product.class)
+                    .set(field("name"), "랜덤다량주문테스트")
+                    .set(field("category"), "테스트")
+                    .set(field("price"), BigDecimal.valueOf(10000))
+                    .create());
+
+            inventoryRepository.save(ProductInventory.builder()
+                    .product(product)
+                    .stock(INITIAL_STOCK)
+                    .build());
+        }
+
+        @Test
+        void 다양한_수량이_랜덤하게_들어와도_재고는_정확히_처리되어야_한다() throws InterruptedException {
+            long productId = product.getId();
+            int[] 주문수량들 = {4, 5, 3}; // 총 요청 수량: 12 → 재고보다 2 많음
+
+            List<Throwable> errors = new ArrayList<>();
+            List<Integer> 성공수량 = Collections.synchronizedList(new ArrayList<>());
+            CountDownLatch latch = new CountDownLatch(주문수량들.length);
+
+            List<Runnable> tasks = new ArrayList<>();
+            for (int quantity : 주문수량들) {
+                tasks.add(() -> {
+                    try {
+                        inventoryService.decreaseStock(productId, quantity);
+                        성공수량.add(quantity);
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            Collections.shuffle(tasks); // 순서를 랜덤하게 섞음
+            executeConcurrency(tasks);
+            latch.await();
+
+            ProductInventory updated = inventoryRepository.findInventoryByProductId(productId).orElseThrow();
+            int 최종재고 = updated.getStock();
+            int 차감된수량 = 성공수량.stream().mapToInt(Integer::intValue).sum();
+
+            log.warn("▶ 초기 재고: {}", INITIAL_STOCK);
+            log.warn("▶ 최종 재고: {}", 최종재고);
+            log.warn("▶ 차감된 수량: {}", 차감된수량);
+            log.warn("▶ 예외 발생 수: {}", errors.size());
+
+            assertThat(차감된수량)
+                    .withFailMessage("차감 수량이 초기 재고를 초과하면 안 됩니다.")
+                    .isLessThanOrEqualTo(INITIAL_STOCK);
+
+            assertThat(최종재고)
+                    .withFailMessage("재고는 음수가 될 수 없습니다.")
+                    .isGreaterThanOrEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/hhplusecommerce/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/coupon/CouponServiceTest.java
@@ -69,6 +69,7 @@ class CouponServiceTest {
             // given
             CouponCommand command = new CouponCommand(USER_ID, COUPON_ID);
 
+            when(couponRepository.issueCouponAtomically(COUPON_ID)).thenReturn(1);
             when(couponRepository.findByIdForUpdate(COUPON_ID))
                     .thenReturn(Optional.of(coupon));
 
@@ -76,7 +77,6 @@ class CouponServiceTest {
             couponService.issueCoupon(command);
 
             // then
-            assertThat(coupon.getIssuedQuantity()).isEqualTo(1);
             verify(couponHistoryRepository).save(any(CouponHistory.class));
         }
 
@@ -104,6 +104,8 @@ class CouponServiceTest {
         void 존재하지_않는_쿠폰이면_발급할_수_없다() {
             // given
             CouponCommand command = new CouponCommand(USER_ID, COUPON_ID);
+
+            when(couponRepository.issueCouponAtomically(COUPON_ID)).thenReturn(1);
             when(couponRepository.findByIdForUpdate(COUPON_ID)).thenReturn(Optional.empty());
 
             // when & then

--- a/src/test/java/com/hhplusecommerce/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/coupon/CouponServiceTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 class CouponServiceTest {
 
     private static final Long USER_ID = 1L;
-    private static final Long OTHER_USER_ID = 2L;
     private static final Long COUPON_ID = 10L;
     private static final Long COUPON_ISSUE_ID = 100L;
     private static final BigDecimal TOTAL_AMOUNT = BigDecimal.valueOf(10000);
@@ -69,7 +68,9 @@ class CouponServiceTest {
         void 정상적으로_쿠폰이_발급된다() {
             // given
             CouponCommand command = new CouponCommand(USER_ID, COUPON_ID);
-            when(couponRepository.findById(COUPON_ID)).thenReturn(Optional.of(coupon));
+
+            when(couponRepository.findByIdForUpdate(COUPON_ID))
+                    .thenReturn(Optional.of(coupon));
 
             // when
             couponService.issueCoupon(command);
@@ -103,7 +104,7 @@ class CouponServiceTest {
         void 존재하지_않는_쿠폰이면_발급할_수_없다() {
             // given
             CouponCommand command = new CouponCommand(USER_ID, COUPON_ID);
-            when(couponRepository.findById(COUPON_ID)).thenReturn(Optional.empty());
+            when(couponRepository.findByIdForUpdate(COUPON_ID)).thenReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> couponService.issueCoupon(command))

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <!-- Console appender to print logs to the console -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Setting root log level to INFO to reduce log verbosity -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <!-- Setting specific logger for your package (com.hhplusecommerce) to INFO level -->
+    <logger name="com.hhplusecommerce" level="INFO"/>
+
+    <!-- Hibernate SQL logging set to WARN to avoid excessive logging of SQL queries -->
+    <logger name="org.hibernate.SQL" level="WARN"/>
+    <logger name="org.hibernate.type" level="WARN"/>
+
+</configuration>


### PR DESCRIPTION
<br>

# ✅ 보고서 링크

## 👉  **[동시성 이슈 - 비관적 락 vs 낙관적 락](https://domean.tistory.com/330)**

<br><br>


# ✅ 기능별 커밋 정리 - STEP9

### DB Lock 적용

| 설명 | 커밋 |
|------|------|
| feat: 상품 재고 차감 - 비관적 락 적용 | 09381b9 |
| feat: 사용자 잔액 충전/차감 - 낙관적 락 적용 | ad203e8, 2f105d1 |
| feat: 선착순 쿠폰 발급 - 비관적 락 적용 및 동시성 개선 | 1b4a138 |


<br>

## 동시성 테스트 구현

| 설명 | 커밋 |
|------|------|
| test: 상품 재고 차감 - 동시성 테스트 추가 | 79e7fa7 |
| test: 사용자 잔액 충전/차감 - 동시성 테스트 추가 | 835ab22 |
| test: 선착순 쿠폰 발급 - 동시성 테스트 추가 | d92e3c4 |

<br><br>

# ✅ 기능별 커밋 정리 - STEP10

| 설명 | 커밋 |
|------|------|
| feat: 요청 로그 및 트래킹을 위한 MDC 필터 및 logback 설정 추가 | 5c7617e |
| feat: 1시간 이상 결제 대기 중인 주문을 자동 만료시키는 스케줄러 추가 | 25d4895 |

<br><br><br>

# ✅ 리뷰 포인트

1️⃣ 
동시성 테스트 구현이 전반적으로 잘 구현 되었는지 확인 부탁 드립니다.

<br>

 2️⃣
보고서에서 보완해야 할 점이 있다면 피드백 부탁 드립니다.

<br><br><br>

# 이번주 KPT 회고

### 📍 Keep
테스트 케이스에 대해서 전보다는 다양하게 고민해 본 것

### 🙏🏻 Problem
보고서 작성에 많은 시간이 소요됨

### 💫 Try
체력관리, 멘탈관리

