### PR TITLE
[STEP-17] 카프카 기초 학습 및 활용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     testImplementation(libs.rest.assured)
     testImplementation(libs.rest.assured.json.path)
     testImplementation(libs.rest.assured.schema)
+    testImplementation("org.testcontainers:kafka:1.19.3")
 
     implementation("org.springframework.retry:spring-retry")
     implementation("org.springframework:spring-aspects")
@@ -72,6 +73,9 @@ dependencies {
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.redisson:redisson:3.18.1")
+
+    // kafka
+    implementation("org.springframework.kafka:spring-kafka")
 }
 
 java {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,63 @@
-version: '3'
+version: '3.8'
+
 services:
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    ports:
+      - "9092:9092"             # Kafka 클라이언트 기본 포트
+      - "9093:9093"             # KRaft 컨트롤러 통신 포트
+      - "9094:9094"             # 외부 접속용 포트
+    environment:
+      KAFKA_KRAFT_MODE: "true"                              # Zookeeper 없이 KRaft 모드 활성화
+      KAFKA_PROCESS_ROLES: controller,broker                # 컨트롤러 및 브로커 역할 수행
+      KAFKA_NODE_ID: 1                                      # 클러스터 내 고유 노드 ID
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@localhost:9093"   # 컨트롤러 후보 노드 주소
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,EXTERNAL://localhost:9094
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"              # 자동 토픽 생성 비활성화
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1             # 단일 브로커 복제 팩터 1
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER           # 컨트롤러 리스너 이름 지정
+      KAFKA_LOG_RETENTION_HOURS: 168                         # 로그 보존 7일
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0             # 리밸런싱 지연 시간 0
+      CLUSTER_ID: "cluster-dev-AD5E4060-FDC3-4A21-950F-8F50FC85D7FA"
+    volumes:
+      - ./data/kafka:/var/lib/kafka/data                     # Kafka 데이터 저장 위치
+
   mysql:
     image: mysql:8.0
+    container_name: mysql
     ports:
-      - "3306:3306"
+      - "3306:3306"                                          # MySQL 기본 포트
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=application
-      - MYSQL_PASSWORD=application
-      - MYSQL_DATABASE=hhplus
+      MYSQL_ROOT_PASSWORD: root                              # 루트 비밀번호
+      MYSQL_USER: application                                # 일반 사용자
+      MYSQL_PASSWORD: application                            # 사용자 비밀번호
+      MYSQL_DATABASE: hhplus                                 # 기본 데이터베이스명
     volumes:
-      - ./data/mysql/:/var/lib/mysql
+      - ./data/mysql:/var/lib/mysql                          # MySQL 데이터 저장 위치
+
+  redis:
+    image: redis:7.0
+    container_name: redis
+    ports:
+      - "6379:6379"                                          # Redis 기본 포트
+    volumes:
+      - ./data/redis:/data                                   # Redis 데이터 저장 위치
+
+  mongodb:
+    image: mongo:6.0
+    container_name: mongodb
+    ports:
+      - "27017:27017"                                        # MongoDB 기본 포트
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: application                # 루트 사용자명
+      MONGO_INITDB_ROOT_PASSWORD: application                # 루트 비밀번호
+      MONGO_INITDB_DATABASE: display                          # 초기 생성 DB명
+    volumes:
+      - ./data/mongodb:/data/db                              # MongoDB 데이터 저장 위치
 
 networks:
   default:
     driver: bridge
-    

--- a/src/main/java/com/hhplusecommerce/application/outbox/OutboxEventDispatcher.java
+++ b/src/main/java/com/hhplusecommerce/application/outbox/OutboxEventDispatcher.java
@@ -1,0 +1,47 @@
+package com.hhplusecommerce.application.outbox;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.port.OutboxEventPort;
+import com.hhplusecommerce.infrastructure.kafka.producer.KafkaProducer;
+import com.hhplusecommerce.support.notification.SlackNotifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Kafka로 발송되지 않은 Outbox 이벤트를 조회하여 전송하고 상태를 갱신
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxEventDispatcher {
+
+    private final OutboxEventPort outboxEventPort;
+    private final KafkaProducer kafkaProducer;
+    private final SlackNotifier slackNotifier;
+
+    private static final int BATCH_SIZE = 100;
+
+    public void dispatchPendingEvents() {
+        List<OutboxEvent> events = outboxEventPort.findReadyToDispatch(BATCH_SIZE, LocalDateTime.now());
+        for (OutboxEvent event : events) {
+            try {
+                kafkaProducer.send(event.getTopicName(), event.getAggregateId(), event.getPayload());
+                outboxEventPort.update(event.markSuccess());
+            } catch (Exception e) {
+                if (event.getStatus().canRetry()) {
+                    outboxEventPort.update(event.markFailed());
+                } else {
+                    log.error("[Outbox] 재시도 불가능 이벤트 - topicName={}, aggregateId={}, error={}", event.getTopicName(), event.getAggregateId(), e.getMessage(), e);
+                    slackNotifier.send(String.format(
+                            "[Outbox ERROR] 재시도 불가능 이벤트 - topicName=%s, aggregateId=%s",
+                            event.getTopicName(), event.getAggregateId()
+                    ));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/hhplusecommerce/domain/order/event/OrderEvent.java
+++ b/src/main/java/com/hhplusecommerce/domain/order/event/OrderEvent.java
@@ -2,6 +2,9 @@ package com.hhplusecommerce.domain.order.event;
 
 import com.hhplusecommerce.domain.order.OrderItems;
 
+/**
+ * 주문 도메인 이벤트 정의
+ */
 public class OrderEvent {
 
     public static class Completed {
@@ -28,6 +31,14 @@ public class OrderEvent {
         public void setTraceContext(String traceId, String spanId) {
             this.traceId = traceId;
             this.spanId = spanId;
+        }
+
+        public String aggregateType() {
+            return "order";
+        }
+
+        public String aggregateId() {
+            return String.valueOf(orderItems.getOrderId());
         }
     }
 }

--- a/src/main/java/com/hhplusecommerce/domain/outbox/model/OutboxEvent.java
+++ b/src/main/java/com/hhplusecommerce/domain/outbox/model/OutboxEvent.java
@@ -1,0 +1,81 @@
+package com.hhplusecommerce.domain.outbox.model;
+
+import com.hhplusecommerce.domain.outbox.type.OutboxStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@Table(name = "outbox_event")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String aggregateType;
+    private String aggregateId;
+    private String topicName;
+    private String payload;
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+    private int retryCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime nextRetryAt;
+
+    public static OutboxEvent create(String aggregateType, String aggregateId, String topicName, String payload) {
+        return OutboxEvent.builder()
+                .id(null)
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .topicName(topicName)
+                .payload(payload)
+                .status(OutboxStatus.WAITING_FOR_PUBLISH)
+                .retryCount(0)
+                .createdAt(LocalDateTime.now())
+                .nextRetryAt(LocalDateTime.now())
+                .build();
+    }
+
+    public OutboxEvent markSuccess() {
+        return this.toBuilder()
+                .status(OutboxStatus.SUCCESS)
+                .build();
+    }
+
+    /**
+     * 재시도 실패 처리
+     * - 지수 백오프 방식으로 재시도 대기 시간을 계산하여 nextRetryAt에 설정
+     * - 기본 대기 시간(baseDelaySeconds)부터 시작해 재시도 횟수마다 2배씩 증가
+     *   (예: 1차 재시도 30초, 2차 60초, 3차 120초, ...)
+     */
+    public OutboxEvent markFailed() {
+        int nextRetry = retryCount + 1;
+        long baseDelaySeconds = 30;
+        long delaySeconds = baseDelaySeconds * (1L << (nextRetry - 1));
+
+        return toBuilder()
+                .status(OutboxStatus.FAILED)
+                .retryCount(nextRetry)
+                .nextRetryAt(LocalDateTime.now().plusSeconds(delaySeconds))
+                .build();
+    }
+
+    public OutboxEvent.OutboxEventBuilder toBuilder() {
+        return OutboxEvent.builder()
+                .id(id)
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .topicName(topicName)
+                .payload(payload)
+                .status(status)
+                .retryCount(retryCount)
+                .createdAt(createdAt)
+                .nextRetryAt(nextRetryAt);
+    }
+}
+

--- a/src/main/java/com/hhplusecommerce/domain/outbox/port/OutboxEventPort.java
+++ b/src/main/java/com/hhplusecommerce/domain/outbox/port/OutboxEventPort.java
@@ -1,0 +1,18 @@
+package com.hhplusecommerce.domain.outbox.port;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * OutBox 이벤트 저장, 조회, 상태 변경 기능 인터페이스
+ */
+public interface OutboxEventPort {
+    void save(OutboxEvent event);
+    List<OutboxEvent> findReadyToDispatch(int batchSize, LocalDateTime now);
+    void update(OutboxEvent event);
+    Optional<OutboxEvent> findByAggregateIdAndTopic(String aggregateId, String topicName);
+
+}

--- a/src/main/java/com/hhplusecommerce/domain/outbox/service/OutboxEventService.java
+++ b/src/main/java/com/hhplusecommerce/domain/outbox/service/OutboxEventService.java
@@ -1,0 +1,24 @@
+package com.hhplusecommerce.domain.outbox.service;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.port.OutboxEventPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxEventService {
+
+    private final OutboxEventPort outboxEventPort;
+
+    public void save(OutboxEvent event) {
+        outboxEventPort.save(event);
+    }
+
+    public Optional<OutboxEvent> findByAggregateIdAndTopic(String aggregateId, String topicName) {
+        return outboxEventPort.findByAggregateIdAndTopic(aggregateId, topicName);
+    }
+
+}

--- a/src/main/java/com/hhplusecommerce/domain/outbox/type/OutboxStatus.java
+++ b/src/main/java/com/hhplusecommerce/domain/outbox/type/OutboxStatus.java
@@ -1,0 +1,45 @@
+package com.hhplusecommerce.domain.outbox.type;
+
+public enum OutboxStatus {
+
+    WAITING_FOR_PUBLISH("처리 대기 중") {
+        @Override
+        public boolean canRetry() {
+            return true; // 재시도 가능
+        }
+    },
+
+    SUCCESS("처리 완료") {
+        @Override
+        public boolean canRetry() {
+            return false; // 성공 상태는 재시도 불필요
+        }
+    },
+
+    FAILED("처리 실패") {
+        @Override
+        public boolean canRetry() {
+            return true; // 실패 시 재시도 가능
+        }
+    };
+
+    private final String description;
+
+    OutboxStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * 재시도 가능한지 여부 반환
+     */
+    public abstract boolean canRetry();
+
+    @Override
+    public String toString() {
+        return name() + "(" + description + ")";
+    }
+}

--- a/src/main/java/com/hhplusecommerce/infrastructure/kafka/consumer/OrderCompletedConsumer.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/kafka/consumer/OrderCompletedConsumer.java
@@ -1,0 +1,37 @@
+package com.hhplusecommerce.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hhplusecommerce.domain.order.OrderItems;
+import com.hhplusecommerce.application.external.DataPlatformExporter;
+import com.hhplusecommerce.support.notification.SlackNotifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCompletedConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final DataPlatformExporter dataPlatformExporter;
+    private final SlackNotifier slackNotifier;
+
+    @KafkaListener(
+            topics = "${custom.kafka.topic.order-completed}",
+            groupId = "${custom.kafka.consumer.group-id.order-data-platform}"
+    )
+    public void listen(ConsumerRecord<String, String> record) {
+        try {
+            OrderItems orderItems = objectMapper.readValue(record.value(), OrderItems.class);
+            dataPlatformExporter.sendOrder(orderItems);
+
+            log.info("[Kafka] 주문 이벤트 수신 및 처리 완료 - orderId={}", orderItems.getOrderId());
+        } catch (Exception e) {
+            log.error("[Kafka] 주문 이벤트 처리 실패: {}", record.value(), e);
+            slackNotifier.send("[Kafka ERROR] 주문 이벤트 처리 실패 - payload=" + record.value());
+        }
+    }
+}

--- a/src/main/java/com/hhplusecommerce/infrastructure/kafka/producer/KafkaProducer.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/kafka/producer/KafkaProducer.java
@@ -1,0 +1,28 @@
+package com.hhplusecommerce.infrastructure.kafka.producer;
+
+import com.hhplusecommerce.support.notification.SlackNotifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka 메시지를 발행하고 실패 시 알림을 보내는 컴포넌트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final SlackNotifier slackNotifier;
+
+    public void send(String topic, String key, String value) {
+        try {
+            kafkaTemplate.send(topic, key, value);
+        } catch (Exception ex) {
+            log.error("[Kafka] 발행 실패 - topic={}, key={}, error={}", topic, key, ex.getMessage(), ex);
+            slackNotifier.send("[Kafka ERROR] 메시지 발행 실패 - topic=" + topic + ", key=" + key);
+        }
+    }
+}

--- a/src/main/java/com/hhplusecommerce/infrastructure/outbox/OutboxEventJpaRepository.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/outbox/OutboxEventJpaRepository.java
@@ -1,0 +1,31 @@
+package com.hhplusecommerce.infrastructure.outbox;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.type.OutboxStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OutboxEventJpaRepository extends JpaRepository<OutboxEvent, Long> {
+    @Query("""
+    SELECT o FROM OutboxEvent o
+    WHERE o.status IN :statuses
+      AND o.nextRetryAt <= :now
+    ORDER BY o.createdAt ASC
+    """)
+    List<OutboxEvent> findReadyToDispatch(
+            @Param("statuses") List<OutboxStatus> statuses,
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
+
+    Optional<OutboxEvent> findByAggregateIdAndTopicName(String aggregateId, String topicName);
+
+}

--- a/src/main/java/com/hhplusecommerce/infrastructure/outbox/OutboxEventRepositoryAdapter.java
+++ b/src/main/java/com/hhplusecommerce/infrastructure/outbox/OutboxEventRepositoryAdapter.java
@@ -1,0 +1,43 @@
+package com.hhplusecommerce.infrastructure.outbox;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.port.OutboxEventPort;
+import com.hhplusecommerce.domain.outbox.type.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxEventRepositoryAdapter implements OutboxEventPort {
+
+    private final OutboxEventJpaRepository jpaRepository;
+
+    @Override
+    public void save(OutboxEvent event) {
+        jpaRepository.save(event);
+    }
+
+    @Override
+    public List<OutboxEvent> findReadyToDispatch(int batchSize, LocalDateTime now) {
+        Pageable pageable = PageRequest.of(0, batchSize);
+        List<OutboxStatus> statuses = List.of(OutboxStatus.WAITING_FOR_PUBLISH, OutboxStatus.FAILED);
+
+        return jpaRepository.findReadyToDispatch(statuses, now, pageable);
+    }
+
+    @Override
+    public void update(OutboxEvent event) {
+        jpaRepository.save(event);
+    }
+
+    @Override
+    public Optional<OutboxEvent> findByAggregateIdAndTopic(String aggregateId, String topicName) {
+        return jpaRepository.findByAggregateIdAndTopicName(aggregateId, topicName);
+    }
+}

--- a/src/main/java/com/hhplusecommerce/interfaces/event/dataPlatform/OrderDataEventListener.java
+++ b/src/main/java/com/hhplusecommerce/interfaces/event/dataPlatform/OrderDataEventListener.java
@@ -1,76 +1,95 @@
 package com.hhplusecommerce.interfaces.event.dataPlatform;
 
-import com.hhplusecommerce.application.external.DataPlatformExporter;
-import com.hhplusecommerce.domain.order.OrderItems;
-import com.hhplusecommerce.domain.order.event.OrderEvent.Completed;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hhplusecommerce.domain.order.event.OrderEvent;
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.service.OutboxEventService;
+import com.hhplusecommerce.infrastructure.kafka.producer.KafkaProducer;
 import com.hhplusecommerce.support.notification.SlackNotifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 @Slf4j
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class OrderDataEventListener {
 
-    private final DataPlatformExporter dataPlatformExporter;
+    private final KafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
     private final SlackNotifier slackNotifier;
 
-    private final List<Completed> eventBuffer = Collections.synchronizedList(new ArrayList<>());
-    private final int batchSize = 100;
+    @Value("${custom.kafka.topic.order-completed}")
+    private String topicName;
 
+    /**
+     * 트랜잭션 커밋 전에 Outbox 테이블에 저장
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveOutbox(OrderEvent.Completed event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            OutboxEvent outboxEvent = OutboxEvent.create(
+                    event.aggregateType(),
+                    event.aggregateId(),
+                    topicName,
+                    payload
+            );
+            outboxEventService.save(outboxEvent);
+        } catch (Exception e) {
+            log.error("[Outbox] 저장 실패 - orderId={}", event.aggregateId(), e);
+            slackNotifier.send(String.format("[Outbox 저장 실패] orderId=%s, traceId=%s, spanId=%s",
+                    event.aggregateId(),
+                    event.getTraceId(),
+                    event.getSpanId())
+            );
+
+        }
+    }
+
+    /**
+     * 트랜잭션 커밋 이후 Kafka로 비동기 전송
+     */
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void bufferEvent(Completed event) {
-        eventBuffer.add(event);
+    public void sendToKafka(OrderEvent.Completed event) {
+        String payload = toJson(event);
+        try {
+            kafkaProducer.send(topicName, event.aggregateId(), payload);
+        } catch (Exception e) {
+            log.error("[Kafka] 발행 실패 - eventType={}, orderId={}, error={}", topicName, event.aggregateId(), e.getMessage(), e);
+            slackNotifier.send(String.format("[Kafka 전송 실패] topic=%s, orderId=%s", topicName, event.aggregateId()));
 
-        if (eventBuffer.size() >= batchSize) {
-            processBatch();
-        }
-    }
+            Optional<OutboxEvent> existingOutboxEvent = outboxEventService.findByAggregateIdAndTopic(
+                    event.aggregateId(), topicName
+            );
 
-    @Scheduled(fixedDelay = 5000)
-    public void processRemainingEvents() {
-        if (!eventBuffer.isEmpty()) {
-            processBatch();
-        }
-    }
-
-    private void processBatch() {
-        List<Completed> batch;
-        synchronized (eventBuffer) {
-            batch = new ArrayList<>(eventBuffer);
-            eventBuffer.clear();
-        }
-
-        if (!batch.isEmpty()) {
-            try {
-                List<OrderItems> orders = batch.stream()
-                        .map(Completed::getOrderItems)
-                        .collect(Collectors.toList());
-                dataPlatformExporter.sendBatchData(orders);
-                log.info("Successfully processed batch of {} events", batch.size());
-            } catch (Exception e) {
-                log.error("Failed to process batch of {} events", batch.size(), e);
-                // 실패한 이벤트 개별 처리 또는 재시도 로직 추가 가능
-                batch.forEach(this::retryIndividualEvent);
+            if (existingOutboxEvent.isPresent()) {
+                OutboxEvent failed = existingOutboxEvent.get().markFailed();
+                outboxEventService.save(failed);
+            } else {
+                log.warn("[Kafka] 실패 이벤트 OutboxEvent 찾을 수 없음 - orderId={}", event.aggregateId());
             }
         }
     }
 
-    private void retryIndividualEvent(Completed event) {
+    public String toJson(OrderEvent.Completed event) {
         try {
-            dataPlatformExporter.sendOrder(event.getOrderItems());
+            return objectMapper.writeValueAsString(event);
         } catch (Exception e) {
-            log.error("[Retry Failed] orderId={}", event.getOrderItems().getOrderId(), e);
-            slackNotifier.send("[Retry Failed] 주문 이벤트 처리 실패 - orderId=" + event.getOrderItems().getOrderId());
+            log.error("[Kafka] JSON 직렬화 실패 - eventType={}, aggregateId={}, error={}",
+                    topicName, event.aggregateId(), e.getMessage(), e);
+            throw new RuntimeException(
+                    String.format("JSON 직렬화 실패: eventType=%s, aggregateId=%s", topicName, event.aggregateId()), e);
         }
     }
 }

--- a/src/main/java/com/hhplusecommerce/interfaces/scheduler/OutboxEventDispatcherScheduler.java
+++ b/src/main/java/com/hhplusecommerce/interfaces/scheduler/OutboxEventDispatcherScheduler.java
@@ -1,0 +1,21 @@
+package com.hhplusecommerce.interfaces.scheduler;
+
+import com.hhplusecommerce.application.outbox.OutboxEventDispatcher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka로 전송되지 않은 Outbox 이벤트를 주기적으로 조회하고 발송하는 스케줄러
+ */
+@Component
+@RequiredArgsConstructor
+public class OutboxEventDispatcherScheduler {
+
+    private final OutboxEventDispatcher outboxEventDispatcher;
+
+    @Scheduled(fixedDelay = 5000)
+    public void dispatchPendingEvents() {
+        outboxEventDispatcher.dispatchPendingEvents();
+    }
+}

--- a/src/main/java/com/hhplusecommerce/support/config/KafkaConfiguration.java
+++ b/src/main/java/com/hhplusecommerce/support/config/KafkaConfiguration.java
@@ -1,0 +1,40 @@
+package com.hhplusecommerce.support.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Profile("!test")
+@Configuration
+public class KafkaConfiguration {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,9 +22,12 @@ spring:
       hibernate.jdbc.time_zone: UTC
 
 custom:
-  cache:
-    popular-products:
-      ttl: 60s
+  kafka:
+    topic:
+      order-completed: order.completed.v1
+    consumer:
+      group-id:
+        order-data-platform: order-data-platform-consumer
 
 ---
 
@@ -43,8 +46,25 @@ spring:
       hibernate:
         format_sql: true
 
+  kafka:
+    bootstrap-servers: localhost:9092              # Kafka 브로커 주소
+    producer:
+      client-id: hhplus-producer                   # 프로듀서 클라이언트 아이디
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      retries: 5                                   # 전송 실패 시 최대 재시도 횟수
+    consumer:
+      group-id: order-data-platform-consumer       # 컨슈머 그룹 아이디
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        enable-auto-commit: false                   # 자동 커밋 비활성화 (수동 커밋 권장)
+    listener:
+      concurrency: 2                                # 동시 처리 스레드 수 (성능 향상용)
+      ack-mode: manual                              # 메시지 수신 후 수동으로 커밋 처리
+
 redisson:
-  address: redis://127.0.0.1:6379
+  address: redis://127.0.0.1:6379                   # Redis 접속 주소
 
 ---
 
@@ -62,3 +82,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+test:
+  kafka:
+    groupId: test-group-${random.uuid}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,23 +4,27 @@
     <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
     <property name="LOG_PATTERN_WITH_MDC" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{requestId}] - %msg%n"/>
 
-    <!-- Console appender to print logs to the console -->
+    <!-- 콘솔 출력 설정 -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>${LOG_PATTERN_WITH_MDC}</pattern>
         </encoder>
     </appender>
 
-    <!-- Setting root log level to INFO to reduce log verbosity -->
+    <!-- 전체 로그 INFO -->
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <!-- Setting specific logger for your package (com.hhplusecommerce) to INFO level -->
+    <!-- 특정 패키지 INFO -->
     <logger name="com.hhplusecommerce" level="INFO"/>
 
-    <!-- Hibernate SQL logging set to WARN to avoid excessive logging of SQL queries -->
+    <!-- Hibernate SQL 쿼리 로그 경고 이상만 -->
     <logger name="org.hibernate.SQL" level="WARN"/>
     <logger name="org.hibernate.type" level="WARN"/>
+
+    <!-- Kafka 네트워크 관련 로그 ERROR로 제한 -->
+    <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
+    <logger name="org.springframework.kafka" level="ERROR"/>
 
 </configuration>

--- a/src/test/java/com/hhplusecommerce/application/outbox/OutboxEventDispatcherTest.java
+++ b/src/test/java/com/hhplusecommerce/application/outbox/OutboxEventDispatcherTest.java
@@ -1,0 +1,132 @@
+package com.hhplusecommerce.application.outbox;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.port.OutboxEventPort;
+import com.hhplusecommerce.domain.outbox.type.OutboxStatus;
+import com.hhplusecommerce.infrastructure.kafka.producer.KafkaProducer;
+import com.hhplusecommerce.support.notification.SlackNotifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventDispatcherTest {
+
+    private static final String AGGREGATE_TYPE = "Order";
+    private static final String AGGREGATE_ID = "123";
+    private static final String TOPIC_NAME = "order-topic";
+    private static final String PAYLOAD = "{}";
+
+    @Mock
+    private OutboxEventPort outboxEventPort;
+    @Mock
+    private KafkaProducer kafkaProducer;
+    @Mock
+    private SlackNotifier slackNotifier;
+    @InjectMocks
+    private OutboxEventDispatcher dispatcher;
+
+    @Nested
+    class nextRetryAt_시간이_지났을_때 {
+        @Test
+        void 이벤트를_전송하고_성공처리한다() {
+            // given
+            OutboxEvent event = OutboxEvent.builder()
+                    .id(1L)
+                    .aggregateType(AGGREGATE_TYPE)
+                    .aggregateId(AGGREGATE_ID)
+                    .topicName(TOPIC_NAME)
+                    .payload(PAYLOAD)
+                    .status(OutboxStatus.WAITING_FOR_PUBLISH)
+                    .retryCount(0)
+                    .createdAt(LocalDateTime.now().minusMinutes(10))
+                    .nextRetryAt(LocalDateTime.now().minusMinutes(1))
+                    .build();
+
+            when(outboxEventPort.findReadyToDispatch(anyInt(), any())).thenReturn(List.of(event));
+
+            // when
+            dispatcher.dispatchPendingEvents();
+
+            // then
+            verify(kafkaProducer, times(1)).send(eq(TOPIC_NAME), eq(AGGREGATE_ID), eq(PAYLOAD));
+
+            ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+            verify(outboxEventPort).update(captor.capture());
+
+            OutboxEvent updated = captor.getValue();
+            assertThat(updated.getStatus()).isEqualTo(OutboxStatus.SUCCESS);
+        }
+    }
+
+    @Nested
+    class nextRetryAt_시간이_안_지났을_때 {
+        @Test
+        void 이벤트를_전송하지_않는다() {
+            // given
+            OutboxEvent event = OutboxEvent.builder()
+                    .id(2L)
+                    .aggregateType(AGGREGATE_TYPE)
+                    .aggregateId(AGGREGATE_ID)
+                    .topicName(TOPIC_NAME)
+                    .payload(PAYLOAD)
+                    .status(OutboxStatus.FAILED)
+                    .retryCount(1)
+                    .createdAt(LocalDateTime.now().minusMinutes(10))
+                    .nextRetryAt(LocalDateTime.now().plusMinutes(5))
+                    .build();
+
+            when(outboxEventPort.findReadyToDispatch(anyInt(), any())).thenReturn(List.of());
+
+            // when
+            dispatcher.dispatchPendingEvents();
+
+            // then
+            verify(kafkaProducer, never()).send(any(), any(), any());
+            verify(outboxEventPort, never()).update(any());
+        }
+    }
+
+    @Nested
+    class 예외가_발생했을_때 {
+        @Test
+        void 재시도_가능한_이벤트는_실패로_표시한다() {
+            // given
+            OutboxEvent event = OutboxEvent.builder()
+                    .id(3L)
+                    .aggregateType(AGGREGATE_TYPE)
+                    .aggregateId(AGGREGATE_ID)
+                    .topicName(TOPIC_NAME)
+                    .payload(PAYLOAD)
+                    .status(OutboxStatus.WAITING_FOR_PUBLISH)
+                    .retryCount(1)
+                    .createdAt(LocalDateTime.now().minusMinutes(10))
+                    .nextRetryAt(LocalDateTime.now().minusMinutes(1))
+                    .build();
+
+            when(outboxEventPort.findReadyToDispatch(anyInt(), any())).thenReturn(List.of(event));
+            doThrow(new RuntimeException("Kafka 전송 실패")).when(kafkaProducer).send(any(), any(), any());
+
+            // when
+            dispatcher.dispatchPendingEvents();
+
+            // then
+            verify(outboxEventPort).update(argThat(e ->
+                    e.getStatus() == OutboxStatus.FAILED &&
+                            e.getRetryCount() == event.getRetryCount() + 1
+            ));
+        }
+    }
+}

--- a/src/test/java/com/hhplusecommerce/domain/outbox/OutboxEventTest.java
+++ b/src/test/java/com/hhplusecommerce/domain/outbox/OutboxEventTest.java
@@ -1,0 +1,63 @@
+package com.hhplusecommerce.domain.outbox;
+
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.type.OutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OutboxEventTest {
+
+    private static final String AGGREGATE_TYPE = "Order";
+    private static final String AGGREGATE_ID = "123";
+    private static final String TOPIC_NAME = "order-topic";
+    private static final String PAYLOAD = "{}";
+
+    private OutboxEvent event;
+
+    @BeforeEach
+    void setUp() {
+        event = OutboxEvent.builder()
+                .id(1L)
+                .aggregateType(AGGREGATE_TYPE)
+                .aggregateId(AGGREGATE_ID)
+                .topicName(TOPIC_NAME)
+                .payload(PAYLOAD)
+                .status(OutboxStatus.WAITING_FOR_PUBLISH)
+                .retryCount(0)
+                .createdAt(LocalDateTime.now().minusMinutes(10))
+                .nextRetryAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Nested
+    class 재시도_실패_처리_테스트 {
+
+        @Test
+        void retryCount가_1증가하고_nextRetryAt이_뒤로_밀리며_status가_FAILED로_변경된다() {
+            OutboxEvent failedEvent = event.markFailed();
+
+            assertThat(failedEvent.getRetryCount()).isEqualTo(event.getRetryCount() + 1);
+            assertThat(failedEvent.getNextRetryAt()).isAfter(event.getNextRetryAt());
+            assertThat(failedEvent.getStatus()).isEqualTo(OutboxStatus.FAILED);
+            assertThat(failedEvent.getAggregateId()).isEqualTo(event.getAggregateId());
+            assertThat(failedEvent.getPayload()).isEqualTo(event.getPayload());
+        }
+    }
+
+    @Nested
+    class 성공_처리_테스트 {
+
+        @Test
+        void status가_SUCCESS로_변경되고_retryCount는_변하지_않는다() {
+            OutboxEvent successEvent = event.markSuccess();
+
+            assertThat(successEvent.getStatus()).isEqualTo(OutboxStatus.SUCCESS);
+            assertThat(successEvent.getRetryCount()).isEqualTo(event.getRetryCount());
+        }
+    }
+}

--- a/src/test/java/com/hhplusecommerce/integration/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/com/hhplusecommerce/integration/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.hhplusecommerce.integration.kafka;
+
+import com.hhplusecommerce.support.IntegrationTestSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class KafkaIntegrationTest extends IntegrationTestSupport {
+
+    private static final String TEST_MESSAGE = "hello kafka";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private KafkaTestConsumer kafkaTestConsumer;
+
+    @BeforeEach
+    void resetConsumer() {
+        kafkaTestConsumer.reset();
+    }
+
+    @Test
+    void verifyMessageReceivedOnTestTopic() throws Exception {
+        mockMvc.perform(post("/kafka/publish")
+                        .param("message", TEST_MESSAGE))
+                .andExpect(status().isOk());
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> assertThat(kafkaTestConsumer.getMessageCount()).isGreaterThan(0));
+    }
+}

--- a/src/test/java/com/hhplusecommerce/integration/kafka/KafkaTestConsumer.java
+++ b/src/test/java/com/hhplusecommerce/integration/kafka/KafkaTestConsumer.java
@@ -1,0 +1,28 @@
+package com.hhplusecommerce.integration.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+@Slf4j
+public class KafkaTestConsumer {
+
+    private final AtomicLong messageCount = new AtomicLong(0);
+
+    @KafkaListener(topics = "test-topic", groupId = "${test.kafka.groupId}")
+    public void listen(String message) {
+        log.info("Received message: {}", message);
+        messageCount.incrementAndGet();
+    }
+
+    public long getMessageCount() {
+        return messageCount.get();
+    }
+
+    public void reset() {
+        messageCount.set(0);
+    }
+}

--- a/src/test/java/com/hhplusecommerce/integration/kafka/KafkaTestController.java
+++ b/src/test/java/com/hhplusecommerce/integration/kafka/KafkaTestController.java
@@ -1,0 +1,18 @@
+package com.hhplusecommerce.integration.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class KafkaTestController {
+
+    private final KafkaTestProducer producer;
+
+    @PostMapping("/kafka/publish")
+    public ResponseEntity<String> publish(@RequestParam String message) {
+        producer.sendMessage(message);
+        return ResponseEntity.ok("Message sent: " + message);
+    }
+}

--- a/src/test/java/com/hhplusecommerce/integration/kafka/KafkaTestProducer.java
+++ b/src/test/java/com/hhplusecommerce/integration/kafka/KafkaTestProducer.java
@@ -1,0 +1,21 @@
+package com.hhplusecommerce.integration.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaTestProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private static final String TOPIC = "test-topic";
+
+    public void sendMessage(String message) {
+        kafkaTemplate.send(TOPIC, message);
+        log.info("Sent message='{}' to topic='{}'", message, TOPIC);
+    }
+}

--- a/src/test/java/com/hhplusecommerce/interfaces/event/dataPlatform/OrderDataEventListenerTest.java
+++ b/src/test/java/com/hhplusecommerce/interfaces/event/dataPlatform/OrderDataEventListenerTest.java
@@ -1,57 +1,170 @@
 package com.hhplusecommerce.interfaces.event.dataPlatform;
 
-import com.hhplusecommerce.application.external.DataPlatformExporter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hhplusecommerce.domain.order.Order;
-import com.hhplusecommerce.domain.order.OrderItem;
-import com.hhplusecommerce.domain.order.OrderItems;
+import com.hhplusecommerce.domain.order.OrderCommand;
+import com.hhplusecommerce.domain.order.OrderItemCommand;
 import com.hhplusecommerce.domain.order.event.OrderEvent;
+import com.hhplusecommerce.domain.outbox.model.OutboxEvent;
+import com.hhplusecommerce.domain.outbox.service.OutboxEventService;
+import com.hhplusecommerce.domain.outbox.type.OutboxStatus;
+import com.hhplusecommerce.infrastructure.kafka.producer.KafkaProducer;
+import com.hhplusecommerce.support.notification.SlackNotifier;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class OrderDataEventListenerTest {
-    private static final Long PRODUCT_ID = 100L;
-    private static final int QUANTITY = 2;
-    private static final BigDecimal UNIT_PRICE = BigDecimal.valueOf(5000);
-    private static final String CATEGORY = "book";
+    private static final String TEST_TOPIC_NAME = "order-completed-topic";
+    private static final Long TEST_ORDER_ID = 1L;
+    private static final Long TEST_USER_ID = 100L;
+    private static final Long TEST_PRODUCT_ID = 10L;
+    private static final int TEST_QUANTITY = 2;
+    private static final BigDecimal TEST_PRICE = BigDecimal.valueOf(10000);
+    private static final String TEST_CATEGORY = "ELECTRONICS";
+    private static final String MOCKED_EVENT_PAYLOAD = "{\"key\":\"value\"}";
 
     @Mock
-    private DataPlatformExporter dataPlatformExporter;
+    private KafkaProducer kafkaProducer;
+    @Mock
+    private OutboxEventService outboxEventService;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private SlackNotifier slackNotifier;
 
     @InjectMocks
     private OrderDataEventListener listener;
 
-    private OrderItems createOrderItems() {
-        Order mockOrder = mock(Order.class);
-        OrderItem item = new OrderItem(mockOrder, PRODUCT_ID, QUANTITY, UNIT_PRICE, CATEGORY);
+    private OrderEvent.Completed testOrderCompletedEvent;
 
-        return new OrderItems(List.of(item));
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(listener, "topicName", TEST_TOPIC_NAME);
+
+        OrderItemCommand itemCommand = new OrderItemCommand(
+                TEST_PRODUCT_ID, TEST_QUANTITY, TEST_PRICE, TEST_CATEGORY);
+
+        OrderCommand command = new OrderCommand(
+                TEST_USER_ID,
+                null,
+                List.of(itemCommand)
+        );
+
+        Order order = Order.create(command);
+        ReflectionTestUtils.setField(order, "id", TEST_ORDER_ID);
+
+        testOrderCompletedEvent = new OrderEvent.Completed(order.getOrderItems());
     }
 
     @Nested
-    class 주문완료_이벤트를_수신했을_때 {
+    class Outbox_이벤트_저장_시나리오 {
 
         @Test
-        void 외부플랫폼으로_주문정보전송이_수행된다() {
-            // given
-            OrderItems orderItems = createOrderItems();
-            OrderEvent.Completed event = new OrderEvent.Completed(orderItems);
+        void 주문완료이벤트_수신시_아웃박스에_이벤트가_성공적으로_저장된다() throws Exception {
+            // Given
+            when(objectMapper.writeValueAsString(any(OrderEvent.Completed.class))).thenReturn(MOCKED_EVENT_PAYLOAD);
+            ArgumentCaptor<OutboxEvent> outboxEventCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
 
-            // when
-            listener.bufferEvent(event);
-            listener.processRemainingEvents();
+            // When
+            listener.saveOutbox(testOrderCompletedEvent);
 
-            // then
-            verify(dataPlatformExporter, times(1)).sendBatchData(anyList());
+            // Then
+            verify(outboxEventService, times(1)).save(outboxEventCaptor.capture());
+            OutboxEvent capturedEvent = outboxEventCaptor.getValue();
+
+            assertThat(capturedEvent.getAggregateType()).isEqualTo(testOrderCompletedEvent.aggregateType());
+            assertThat(capturedEvent.getAggregateId()).isEqualTo(String.valueOf(TEST_ORDER_ID));
+            assertThat(capturedEvent.getTopicName()).isEqualTo(TEST_TOPIC_NAME);
+            assertThat(capturedEvent.getPayload()).isEqualTo(MOCKED_EVENT_PAYLOAD);
+            assertThat(capturedEvent.getStatus()).isEqualTo(OutboxStatus.WAITING_FOR_PUBLISH);
+            assertThat(capturedEvent.getRetryCount()).isEqualTo(0);
+            assertThat(capturedEvent.getCreatedAt()).isNotNull();
+            assertThat(capturedEvent.getNextRetryAt()).isNotNull();
+
+            verify(objectMapper, times(1)).writeValueAsString(testOrderCompletedEvent);
+        }
+
+        @Test
+        void 아웃박스_저장중_예외발생시_로그만_남기고_예외가_전파되지_않는다() throws Exception {
+            // Given
+            when(objectMapper.writeValueAsString(any(OrderEvent.Completed.class))).thenReturn(MOCKED_EVENT_PAYLOAD);
+            doThrow(new RuntimeException("DB 저장 실패")).when(outboxEventService).save(any(OutboxEvent.class));
+
+            // When
+            listener.saveOutbox(testOrderCompletedEvent);
+
+            // Then
+            verify(outboxEventService, times(1)).save(any(OutboxEvent.class));
+        }
+    }
+
+    @Nested
+    class Kafka_비동기_전송_시나리오 {
+
+        @Test
+        void 이벤트_수신시_Kafka로_메시지가_성공적으로_발행된다() throws Exception {
+            // Given
+            when(objectMapper.writeValueAsString(any(OrderEvent.Completed.class))).thenReturn(MOCKED_EVENT_PAYLOAD);
+
+            // When
+            listener.sendToKafka(testOrderCompletedEvent);
+
+            // Then
+            verify(objectMapper, times(1)).writeValueAsString(testOrderCompletedEvent);
+            // KafkaProducer.send의 key 인자가 String이므로 Long을 String으로 변환합니다.
+            verify(kafkaProducer, times(1)).send(
+                    eq(TEST_TOPIC_NAME),
+                    eq(String.valueOf(TEST_ORDER_ID)),
+                    eq(MOCKED_EVENT_PAYLOAD)
+            );
+        }
+
+        @Test
+        void Kafka_메시지_발행중_예외발생시_로그만_남기고_예외가_전파되지않는다() throws Exception {
+            // Given
+            when(objectMapper.writeValueAsString(any(OrderEvent.Completed.class))).thenReturn(MOCKED_EVENT_PAYLOAD);
+            doThrow(new RuntimeException("Kafka 전송 실패")).when(kafkaProducer).send(anyString(), anyString(), anyString());
+
+            // When
+            listener.sendToKafka(testOrderCompletedEvent);
+
+            // Then
+            verify(kafkaProducer, times(1)).send(
+                    eq(TEST_TOPIC_NAME),
+                    eq(String.valueOf(TEST_ORDER_ID)),
+                    eq(MOCKED_EVENT_PAYLOAD)
+            );
+        }
+
+        @Test
+        void Kafka_JSON_직렬화_실패시_예외가_발생한다() throws Exception {
+            // Given
+            when(objectMapper.writeValueAsString(any(OrderEvent.Completed.class)))
+                    .thenThrow(new RuntimeException("JSON 직렬화 실패"));
+
+            // When & Then
+            assertThatThrownBy(() -> listener.sendToKafka(testOrderCompletedEvent))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("JSON 직렬화 실패");
+
+            verify(objectMapper, times(1)).writeValueAsString(testOrderCompletedEvent);
+            verify(kafkaProducer, never()).send(anyString(), anyString(), anyString());
         }
     }
 }

--- a/src/test/java/com/hhplusecommerce/support/KafkaTestSupport.java
+++ b/src/test/java/com/hhplusecommerce/support/KafkaTestSupport.java
@@ -1,0 +1,93 @@
+package com.hhplusecommerce.support;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Testcontainers
+@Profile("test")
+@Configuration
+public class KafkaTestSupport {
+
+    private static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:7.4.0");
+
+    @Container
+    private static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer(KAFKA_IMAGE)
+            .withReuse(true)
+            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(2)))
+            .withLogConsumer(new Slf4jLogConsumer(log));
+
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServersFallback;
+
+    @BeforeAll
+    static void setupKafka() {
+        KAFKA_CONTAINER.start();
+        createKafkaTopics(KAFKA_CONTAINER.getBootstrapServers(), "order.completed.v1", "test-topic");
+    }
+
+    @DynamicPropertySource
+    static void registerKafkaProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", KAFKA_CONTAINER::getBootstrapServers);
+    }
+
+    private static void createKafkaTopics(String bootstrapServers, String... topicNames) {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", bootstrapServers);
+        try (AdminClient adminClient = AdminClient.create(props)) {
+            List<NewTopic> topics = Arrays.stream(topicNames)
+                    .map(name -> new NewTopic(name, 1, (short) 1))
+                    .collect(Collectors.toList());
+            adminClient.createTopics(topics).all().get();
+            log.info("Kafka topics created: {}", topics.stream().map(NewTopic::name).collect(Collectors.joining(", ")));
+        } catch (InterruptedException | ExecutionException e) {
+            Thread.currentThread().interrupt();
+            log.error("Failed to create Kafka test topics: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to create Kafka test topics", e);
+        } catch (Exception e) {
+            log.error("Failed to create Kafka test topics (general exception): {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to create Kafka test topics", e);
+        }
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        String bootstrapServers = KAFKA_CONTAINER.isRunning() ? KAFKA_CONTAINER.getBootstrapServers() : bootstrapServersFallback;
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/test/java/com/hhplusecommerce/support/TestcontainersConfiguration.java
+++ b/src/test/java/com/hhplusecommerce/support/TestcontainersConfiguration.java
@@ -3,6 +3,7 @@ package com.hhplusecommerce.support;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -10,6 +11,7 @@ public class TestcontainersConfiguration {
 
     private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0");
     private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:6.2.5");
+    private static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:latest");
 
     private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(MYSQL_IMAGE)
             .withReuse(true)
@@ -21,9 +23,13 @@ public class TestcontainersConfiguration {
             .withReuse(true)
             .withExposedPorts(6379);
 
+    private static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer(KAFKA_IMAGE)
+            .withExposedPorts(9093);
+
     static {
         MYSQL_CONTAINER.start();
         REDIS_CONTAINER.start();
+        KAFKA_CONTAINER.start();
     }
 
     @DynamicPropertySource
@@ -39,5 +45,7 @@ public class TestcontainersConfiguration {
         registry.add("spring.redis.host", () -> redisHost);
         registry.add("spring.redis.port", () -> redisPort);
         registry.add("redisson.address", () -> "redis://" + redisHost + ":" + redisPort);
+
+        registry.add("spring.kafka.bootstrap-servers", KAFKA_CONTAINER::getBootstrapServers);
     }
 }


### PR DESCRIPTION
## ✅ 기능별 커밋 정리

<br>

| 설명 | 커밋 |
|------|------|
| Kafka 설정파일 추가, 테스트 환경 구성 | 24ca4eb |
| Kafka 메시지 발행/소비 흐름 검증 테스트 추가 (카프카 테스트용) | 12733e3 |
| 주문 완료 이벤트 카프카 연동 및 Outbox 패턴 도입 | 0e485f7 |
| Kafka 전송 실패 대응을 위한 Outbox Dispatcher 및 재시도 스케줄러 구현 | a78bd77 |
| Outbox 전송 성공/실패 및 이벤트 리스너 동작 테스트 추가 | 237c394 |
| Apache Kafka 톺아보기 문서 작성 | [ 🟣 바로 가기 ](https://domean.tistory.com/334) |

<br><br>

## ✅ 리뷰 포인트

1️⃣ 
[ 주문 완료 이벤트 발행 구조 개선 – Spring Event 유지 + Kafka (Outbox) 추가 도입 ]

이번 과제는
기존의 `ApplicationEventPublisher` 기반 `Spring Event` 구조를 유지하면서
외부 시스템 연동의 신뢰성과 확장성을 위해 `Kafka`와 `Outbox` 패턴을 도입해 보았습니다.

<br>

🔧 설계 의도 및 구조 분리
- 내부 이벤트
   - 기존과 동일하게 Spring Event를 활용해 애플리케이션 내부 도메인 간 비동기 연동을 처리
   - `AFTER_COMMIT` 리스너에서 동작하며 Kafka와는 무관하게 도메인 로직에 집중
   - 예시: 인기상품 랭킹 갱신, 판매 통계 처리 등

- 외부 이벤트
   - 외부 연동용 이벤트는 `BEFORE_COMMIT` 시점에 Outbox 테이블에 먼저 저장
   - 트랜잭션 커밋 이후 별도의 Kafka 발행 리스너가 1차 전송을 시도
   - 실패해도 Outbox 상태는 유지되며, `Dispatcher`를 통해 재시도 및 상태 갱신
   - 예시: 외부 데이터 플랫폼 연동
    
<br>

이러한 내부/외부 이벤트 분리 및 Kafka 도입 방식이 적절한지,
개선해야 하거나 놓친 점이 있는지 피드백 부탁드립니다.

<br>


```mermaid
flowchart TD
    subgraph Step1: 최종 주문 완료
        A[결제 파사드] --> B[OrderEvent.Completed <br> 이벤트 발행]
    end

    subgraph Step2: 이벤트 리스너 처리
        B --> C[랭킹 리스너 <br> AFTER_COMMIT]
        B --> D[판매 통계 리스너 <br> AFTER_COMMIT]
        B --> E[Outbox 저장 리스너 <br> BEFORE_COMMIT]
        E --> F[Outbox 테이블에 이벤트 저장]
        B --> G[Kafka 전송 리스너 <br> AFTER_COMMIT]
        G --> H[Kafka로 1차 전송 시도]
        H -->|성공| I[Kafka 브로커]
        H -->|실패| J[Kafka 전송 실패 <br> Outbox 상태를 <br> 'WAITING_FOR_PUBLISH' <br> 유지]
    end

    subgraph Step3: Outbox 디스패처 재전송 및 상태 관리
        F --> K[Outbox 이벤트]
        K --> L[Outbox 디스패처 <br> 스케줄러 실행]
        J --> L
        L --> M[발행 대기/재시도 이벤트 조회]
        M --> N[Kafka로 재전송 시도]
        N -->|성공| I
        N -->|실패| O[Outbox 상태: <br> '실패'로 업데이트 <br> + 재시도 시간 갱신 ]
        I --> P[Outbox 상태: <br> '발행완료'로 업데이트]
    end

    subgraph Step4: Kafka 컨슈머 후처리
        I --> Q[Kafka Consumer]
        Q --> R[외부 데이터 플랫폼 전송]
    end
```
